### PR TITLE
Rename args to include/exclude

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,8 +150,8 @@ Install this package with `pip`.
 
 ```
 > maco --help
-usage: maco [-h] [-v] [--pretty] [--logfile LOGFILE] [--whitelist WHITELIST]
-            [--blacklist BLACKLIST]
+usage: maco [-h] [-v] [--pretty] [--logfile LOGFILE] [--include INCLUDE]
+            [--exclude EXCLUDE]
             extractors samples
 
 Run extractors over samples.
@@ -166,16 +166,16 @@ optional arguments:
                         cli debug
   --pretty              pretty print json output
   --logfile LOGFILE     file to log output
-  --whitelist WHITELIST
+  --include INCLUDE
                         comma separated extractors to run
-  --blacklist BLACKLIST
+  --exclude EXCLUDE
                         comma separated extractors to not run
 ```
 
 ## CLI output example
 
 ```
-> maco demo_extractors/ /usr/lib --whitelist Complex
+> maco demo_extractors/ /usr/lib --include Complex
 extractors loaded: ['Complex']
 
 complex by blue 2022-06-14 TLP:WHITE

--- a/maco/base_test.py
+++ b/maco/base_test.py
@@ -31,7 +31,7 @@ class BaseTest(unittest.TestCase):
     def setUp(self) -> None:
         if not self.name or not self.path:
             raise Exception("name and path must be set")
-        self.c = collector.Collector(self.path, whitelist=self.name)
+        self.c = collector.Collector(self.path, include=self.name)
         self.assertIn(self.name, self.c.extractors)
         self.assertEqual(len(self.c.extractors), 1)
         return super().setUp()

--- a/maco/cli.py
+++ b/maco/cli.py
@@ -121,8 +121,8 @@ def main():
         "--exclude", type=str, help="comma separated extractors to not run"
     )
     args = parser.parse_args()
-    wl = args.include.split(",") if args.include else []
-    bl = args.exclude.split(",") if args.exclude else []
+    inc = args.include.split(",") if args.include else []
+    exc = args.exclude.split(",") if args.exclude else []
 
     # set up logging for lib, only show debug with 3+ verbose
     logger_lib = logging.getLogger("maco.lib")
@@ -155,7 +155,7 @@ def main():
         fh.setFormatter(formatter)
         logger.addHandler(fh)
 
-    process_filesystem(args.extractors, args.samples, wl, bl, pretty=args.pretty)
+    process_filesystem(args.extractors, args.samples, inc, exc, pretty=args.pretty)
 
 
 if __name__ == "__main__":

--- a/maco/cli.py
+++ b/maco/cli.py
@@ -51,13 +51,11 @@ def process_file(
 def process_filesystem(
     path_extractors: str,
     path_samples: str,
-    whitelist: List[str],
-    blacklist: List[str],
+    include: List[str],
+    exclude: List[str],
     pretty: bool,
 ):
-    collected = collector.Collector(
-        path_extractors, whitelist=whitelist, blacklist=blacklist
-    )
+    collected = collector.Collector(path_extractors, include=include, exclude=exclude)
 
     logger.info(f"extractors loaded: {[x for x in collected.extractors.keys()]}\n")
     for _, extractor in collected.extractors.items():
@@ -118,15 +116,13 @@ def main():
         "--pretty", action="store_true", help="pretty print json output"
     )
     parser.add_argument("--logfile", type=str, help="file to log output")
+    parser.add_argument("--include", type=str, help="comma separated extractors to run")
     parser.add_argument(
-        "--whitelist", type=str, help="comma separated extractors to run"
-    )
-    parser.add_argument(
-        "--blacklist", type=str, help="comma separated extractors to not run"
+        "--exclude", type=str, help="comma separated extractors to not run"
     )
     args = parser.parse_args()
-    wl = args.whitelist.split(",") if args.whitelist else []
-    bl = args.blacklist.split(",") if args.blacklist else []
+    wl = args.include.split(",") if args.include else []
+    bl = args.exclude.split(",") if args.exclude else []
 
     # set up logging for lib, only show debug with 3+ verbose
     logger_lib = logging.getLogger("maco.lib")

--- a/maco/collector.py
+++ b/maco/collector.py
@@ -23,13 +23,13 @@ class Collector:
     def __init__(
         self,
         path_extractors: str,
-        whitelist: List[str] = None,
-        blacklist: List[str] = None,
+        include: List[str] = None,
+        exclude: List[str] = None,
     ):
         """Discover and load extractors from file system."""
         self.path = path_extractors
-        self.whitelist = whitelist
-        self.blacklist = blacklist
+        self.include = include
+        self.exclude = exclude
 
         self.extractors = self._find_extractors()
 
@@ -75,7 +75,7 @@ class Collector:
                 continue
             logger.debug(f"inspecting '{module_name}' for extractors")
             # raise an exception if one of the potential extractors can't be imported
-            # note that excluding an extractor through white/blacklist does not prevent it being imported
+            # note that excluding an extractor through include/exclude does not prevent it being imported
             module = importlib.import_module(module_name)
 
             # find extractors in the module
@@ -88,11 +88,11 @@ class Collector:
                     continue
                 # check if we want this extractor
                 name = member.__name__
-                if self.blacklist and name in self.blacklist:
-                    logger.debug(f"blacklist excluded '{name}'")
+                if self.exclude and name in self.exclude:
+                    logger.debug(f"exclude excluded '{name}'")
                     continue
-                if self.whitelist and name not in self.whitelist:
-                    logger.debug(f"whitelist excluded '{name}'")
+                if self.include and name not in self.include:
+                    logger.debug(f"include excluded '{name}'")
                     continue
                 # initialise and register
                 logger.debug(f"register '{name}'")


### PR DESCRIPTION
These are more appropriate names for the functionality they implement, to include or exclude specific extractors in a run.