### PR TITLE
Use absolute imports rather than relative

### DIFF
--- a/demo_extractors/complex/complex.py
+++ b/demo_extractors/complex/complex.py
@@ -5,7 +5,7 @@ import yara
 
 from maco import extractor, model
 
-from . import complex_utils
+from demo_extractors.complex import complex_utils
 
 
 class Complex(extractor.Extractor):

--- a/demo_extractors/limit_other.py
+++ b/demo_extractors/limit_other.py
@@ -5,7 +5,7 @@ import yara
 
 from maco import extractor, model
 
-from . import shared
+from demo_extractors import shared
 
 
 class LimitOther(extractor.Extractor):


### PR DESCRIPTION
Throws an error in the configextractor-py library revamp when trying to validate/add the parsers 😅

Tested with MaCo CLI and it still maintains original functionality.