### PR TITLE
Fix bug with inclusion during test execution

### DIFF
--- a/maco/base_test.py
+++ b/maco/base_test.py
@@ -31,7 +31,7 @@ class BaseTest(unittest.TestCase):
     def setUp(self) -> None:
         if not self.name or not self.path:
             raise Exception("name and path must be set")
-        self.c = collector.Collector(self.path, include=self.name)
+        self.c = collector.Collector(self.path, include=[self.name])
         self.assertIn(self.name, self.c.extractors)
         self.assertEqual(len(self.c.extractors), 1)
         return super().setUp()

--- a/tests/extractors/basic.py
+++ b/tests/extractors/basic.py
@@ -1,0 +1,34 @@
+from io import BytesIO
+from typing import List, Optional
+
+import yara
+
+from maco import extractor, model
+
+
+class Basic(extractor.Extractor):
+    """A simplistic script for testing."""
+
+    family = "basic"
+    author = "blue"
+    last_modified = "2022-06-14"
+    yara_rule = """
+        rule Basic
+        {
+            strings:
+                $self_trigger = "Basic"
+
+            condition:
+                $self_trigger
+        }
+        """
+
+    def run(
+        self, stream: BytesIO, matches: List[yara.Match]
+    ) -> Optional[model.ExtractorModel]:
+        # use a custom model that inherits from ExtractorModel
+        # this model defines what can go in the 'other' dict
+        tmp = model.ExtractorModel(family="basic")
+        tmp.campaign_id.append("12345")
+        tmp.other = dict(key1="key1", key2=True, key3=45)
+        return tmp

--- a/tests/extractors/basic_longer.py
+++ b/tests/extractors/basic_longer.py
@@ -1,0 +1,34 @@
+from io import BytesIO
+from typing import List, Optional
+
+import yara
+
+from maco import extractor, model
+
+
+class BasicLonger(extractor.Extractor):
+    """A simplistic script for testing."""
+
+    family = "basic_longer"
+    author = "blue"
+    last_modified = "2022-06-14"
+    yara_rule = """
+        rule BasicLonger
+        {
+            strings:
+                $self_trigger = "BasicLonger"
+
+            condition:
+                $self_trigger
+        }
+        """
+
+    def run(
+        self, stream: BytesIO, matches: List[yara.Match]
+    ) -> Optional[model.ExtractorModel]:
+        # use a custom model that inherits from ExtractorModel
+        # this model defines what can go in the 'other' dict
+        tmp = model.ExtractorModel(family="basic_longer")
+        tmp.campaign_id.append("12345")
+        tmp.other = dict(key1="key1", key2=True, key3=45)
+        return tmp

--- a/tests/extractors/test_basic.py
+++ b/tests/extractors/test_basic.py
@@ -1,0 +1,26 @@
+import io
+import os
+
+from maco import base_test
+
+
+class TestBasicLonger(base_test.BaseTest):
+    """Test that an extractor containing the name of another extractor works properly."""
+
+    name = "BasicLonger"
+    path = os.path.join(__file__, "..")
+
+    def test_run(self):
+        ret = self.extract(io.BytesIO(b"BasicLonger"))
+        self.assertEqual(ret["family"], "basic_longer")
+
+
+class TestBasic(base_test.BaseTest):
+    """Test that an extractor containing the name of another extractor works properly."""
+
+    name = "Basic"
+    path = os.path.join(__file__, "..")
+
+    def test_run(self):
+        ret = self.extract(io.BytesIO(b"Basic"))
+        self.assertEqual(ret["family"], "basic")


### PR DESCRIPTION
There is an issue with test collection where extractors are prefixed with the name of another extractor.

This is because the collector creation was supplying the wrong type (str not List[str]). This PR fixes the issue and adds a test case to prevent regression.