### PR TITLE
Allow family to take a singular string or a list of strings

### DIFF
--- a/maco/extractor.py
+++ b/maco/extractor.py
@@ -18,7 +18,7 @@ class Extractor:
     Override this docstring with a good description of your extractor.
     """
 
-    family: Union[str, List[str]] = None  # family of malware that is detected by the extractor
+    family: Union[str, List[str]] = None  # family or families of malware that is detected by the extractor
     author: str = None  # author of the extractor (name@organisation)
     last_modified: str = None  # last modified date (YYYY-MM-DD)
     sharing: str = "TLP:WHITE"  # who can this be shared with?

--- a/maco/extractor.py
+++ b/maco/extractor.py
@@ -1,7 +1,7 @@
 """Base class for an extractor script."""
 import logging
 import textwrap
-from typing import BinaryIO, List, Optional
+from typing import BinaryIO, List, Optional, Union
 
 import yara
 
@@ -18,7 +18,7 @@ class Extractor:
     Override this docstring with a good description of your extractor.
     """
 
-    family: str = None  # family of malware that is detected by the extractor
+    family: Union[str, List[str]] = None  # family of malware that is detected by the extractor
     author: str = None  # author of the extractor (name@organisation)
     last_modified: str = None  # last modified date (YYYY-MM-DD)
     sharing: str = "TLP:WHITE"  # who can this be shared with?

--- a/maco/model.py
+++ b/maco/model.py
@@ -168,7 +168,7 @@ class ExtractorModel(ForbidModel):
         * Some use cases always seem to exist where a property should not be set
     """
 
-    family: str  # family of malware that was detected
+    family: Union[str, List[str]]  # family of malware that was detected
     version: str = None  # version/variant of malware
     category: List[CategoryEnum] = []  # capability/purpose of the malware
     attack: List[str] = []  # mitre att&ck reference ids, e.g. 'T1129'

--- a/maco/model.py
+++ b/maco/model.py
@@ -168,7 +168,7 @@ class ExtractorModel(ForbidModel):
         * Some use cases always seem to exist where a property should not be set
     """
 
-    family: Union[str, List[str]]  # family of malware that was detected
+    family: Union[str, List[str]]  # family or families of malware that was detected
     version: str = None  # version/variant of malware
     category: List[CategoryEnum] = []  # capability/purpose of the malware
     attack: List[str] = []  # mitre att&ck reference ids, e.g. 'T1129'


### PR DESCRIPTION
Addresses: https://github.com/CybercentreCanada/Maco/issues/8

As described in the issue, the intent is to allow the field to accept both a singular malware family (backwards-compat) or a list of malware families. 