### PR TITLE
Allow extra types on binaries.other field

### DIFF
--- a/maco/model.py
+++ b/maco/model.py
@@ -216,7 +216,7 @@ class ExtractorModel(ForbidModel):
         # other information for the extracted binary rather than the config
         # data stored here must always be JSON-serialisable
         # e.g. filename, extension, relationship label
-        other: Dict[str, Union[List[str], List[int]]] = {}
+        other: Dict[str, Any] = {}
 
         Encryption = Encryption  # convenience for ret.encryption.append(ret.Encryption(*properties))
         encryption: Encryption = None  # encryption information for the binary


### PR DESCRIPTION
When writing extractors, we are encountering a few issues with the 'other' field under the Binary class.

Namely
* single strings/ints are not allowed
* lists of ints are automatically converted to lists of strings by pydantic (!) as it selects the first compatible type
    * from memory there is a pydantic settings to change this behaviour
* We have some more complex data types which require a dictionary
    * e.g. `"taken_from": {"value": "variant-a", "offset": 394, "size": 13}`

I think it would be useful for the typing of this field to match the typing for ExtractorModel.other. As this is loosening the typing rather than restricting, there should be no incompatibility with existing extractors.