### PR TITLE
Path.UsageEnum - add 'config' option

### DIFF
--- a/maco/model.py
+++ b/maco/model.py
@@ -372,6 +372,7 @@ class ExtractorModel(ForbidModel):
 
     class Path(ForbidModel):
         class UsageEnum(str, Enum):
+            config = "config"  # config is loaded from this path
             install = "install"  # install directory/filename for malware
             plugins = "plugins"  # load new capability from this directory
             logs = "logs"  # location to log activity


### PR DESCRIPTION
We have some malware that is reading configuration from certain files on disk, with the path embedded in the malware.