### PR TITLE
Update cli.py

### DIFF
--- a/maco/cli.py
+++ b/maco/cli.py
@@ -204,7 +204,10 @@ def main():
         logger_ex.setLevel(logging.DEBUG)
     ch = logging.StreamHandler(sys.stdout)
     ch.setLevel(logging.DEBUG)
-    formatter = logging.Formatter("%(asctime)s.%(msecs)03d %(levelname)s %(module)s - %(funcName)s: %(message)s")
+    formatter = logging.Formatter(
+        fmt="%(asctime)s, [%(levelname)s] %(module)s.%(funcName)s: %(message)s",
+        datefmt="%Y-%m-%d (%H:%M:%S)"
+    )
     ch.setFormatter(formatter)
     logger_ex.addHandler(ch)
 
@@ -214,7 +217,6 @@ def main():
         logger_lib.setLevel(logging.DEBUG)
         fh = logging.FileHandler(args.logfile)
         fh.setLevel(logging.DEBUG)
-        formatter = logging.Formatter("%(levelname)s - %(name)s - %(message)s")
         fh.setFormatter(formatter)
         logger.addHandler(fh)
 


### PR DESCRIPTION
Improved the formatter datetime format as well as the output value.  

`2023-02-03 (10:56:10), [DEBUG] <class_object_name>.<function_name>:`

Now, the logging level is easiest to read and the `<class_object_name>.<function_name>:` is somewhat similar to the regular code calling convention. The formatter object has been reused for the maco logger instead of creating a new one.