### PR TITLE
Allow lists of Encryption on child binaries

### DIFF
--- a/maco/model/model.py
+++ b/maco/model/model.py
@@ -219,7 +219,7 @@ class ExtractorModel(ForbidModel):
         other: Dict[str, Any] = {}
 
         Encryption = Encryption  # convenience for ret.encryption.append(ret.Encryption(*properties))
-        encryption: Encryption = None  # encryption information for the binary
+        encryption: Union[List[Encryption], Encryption] = None  # encryption information for the binary
 
     binaries: List[Binary] = []
 


### PR DESCRIPTION
Update the model to allow multiple encryption objects on a child binary, to bring it in line with the parent binary, which already allows multiple encryption objects. This implementation is backwards compatible, but could be updated to change the child encryption type to just a list, if backwards compatibility is not a concern. Happy to discuss. 

Updated the model test file to verify that the dictionary returned by the model is the expected dictionary.