### PR TITLE
fix: encoding byte to json failures

### DIFF
--- a/maco/collector.py
+++ b/maco/collector.py
@@ -21,7 +21,7 @@ logger = logging.getLogger("maco.lib.helpers")
 
 
 def _verify_response(resp: BaseModel) -> Dict:
-    """Verify an extractors response model and return a clean Dict representation."""
+    """Enforce types and verify properties, and remove defaults."""
     # check the response is valid for its own model
     # this is useful if a restriction on the 'other' dictionary is needed
     resp_model = type(resp)
@@ -159,7 +159,6 @@ class Collector:
             stream.seek(0)
 
         # enforce types and verify properties, and remove defaults
-        # Dumping to Json to allow for better type conversions (a set and a list are coerced correctly.)
         if resp is not None:
             resp = _verify_response(resp)
 

--- a/maco/collector.py
+++ b/maco/collector.py
@@ -6,7 +6,7 @@ import os
 import pkgutil
 import sys
 from typing import Any, BinaryIO, Dict, List
-from pydantic import TypeAdapter
+from pydantic import BaseModel
 
 import yara
 
@@ -18,6 +18,22 @@ class ExtractorLoadError(Exception):
 
 
 logger = logging.getLogger("maco.lib.helpers")
+
+
+def _verify_response(resp: BaseModel) -> Dict:
+    """Verify an extractors response model and return a clean Dict representation."""
+    # check the response is valid for its own model
+    # this is useful if a restriction on the 'other' dictionary is needed
+    resp_model = type(resp)
+    if resp_model != model.ExtractorModel:
+        resp = resp_model.model_validate(resp)
+    # check the response is valid according to the ExtractorModel
+    resp = model.ExtractorModel.model_validate(resp)
+    # coerce sets to correct types
+    # otherwise we end up with sets where we expect lists
+    resp = model.ExtractorModel(**resp.model_dump())
+    # dump model to dict
+    return resp.model_dump(exclude_defaults=True)
 
 
 class Collector:
@@ -145,16 +161,6 @@ class Collector:
         # enforce types and verify properties, and remove defaults
         # Dumping to Json to allow for better type conversions (a set and a list are coerced correctly.)
         if resp is not None:
-            # check the response is valid for its own model
-            # this is useful if a restriction on the 'other' dictionary is needed
-            resp_model = type(resp)
-            if resp_model != model.ExtractorModel:
-                resp = TypeAdapter(resp_model).validate_json(resp.model_dump_json())
-            # check the response is valid according to the ExtractorModel
-            resp = (
-                TypeAdapter(model.ExtractorModel)
-                .validate_json(resp.model_dump_json())
-                .model_dump(exclude_defaults=True)
-            )
+            resp = _verify_response(resp)
 
         return resp

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -3,10 +3,12 @@ from typing import Dict
 
 from pydantic import ValidationError
 
-from maco import model
+from maco import model, collector
 
 
-class TestModel(unittest.TestCase):
+class TestModelObject(unittest.TestCase):
+    maxDiff = None
+
     def test_model_invalid(self):
         # family not supplied
         self.assertRaises(ValidationError, model.ExtractorModel)
@@ -16,15 +18,296 @@ class TestModel(unittest.TestCase):
         self.assertRaises(ValueError, setattr, *(ret, "invalid", 12345))
         # invalid type
         ret.sleep_delay = "test"
-        self.assertRaises(ValidationError, self.verify, ret.model_dump())
+        self.assertRaises(ValidationError, collector._verify_response, ret)
 
-    def test_model_1(self):
+    def test_model_object_1(self):
         # object example
         tmp = model.ExtractorModel(family="scuba")
         tmp.campaign_id.append("5467")
-        self.verify(tmp.model_dump(), exclude_defaults=False)
+        self.verify(tmp, {"family": "scuba", "campaign_id": ["5467"]})
 
-    def test_model_2(self):
+    def test_model_object_2(self):
+        em = model.ExtractorModel
+        tmp = model.ExtractorModel(
+            family="scuba",
+            version="lotso_stuff",
+            category=[],
+            attack=[],
+            capability_enabled=[],
+            capability_disabled=[],
+            campaign_id=["32"],
+            identifier=["uxuduxuduxuudux"],
+            decoded_strings=["there", "are", "some", "strings"],
+            password=["hunter2"],
+            mutex=["YEAH"],
+            pipe=["xiod"],
+            sleep_delay=45000,
+            inject_exe=["Teams.exe"],
+            other={"misc_data": {"nested": 5}},
+            binaries=[
+                em.Binary(
+                    datatype=None,
+                    data=b"\x10\x20\x30\x40",
+                    other={
+                        "datatype": ["payload"],
+                        "extension": [".invalid"],
+                        "label": ["xor 0x04 at 0x2130-0x2134"],
+                        "some_junk": [1, 2, 3, 4, 5, 6],
+                    },
+                    encryption=em.Binary.Encryption(
+                        algorithm="alxor",
+                        public_key=None,
+                        key=None,
+                        provider=None,
+                        mode=None,
+                        iv=None,
+                        seed=None,
+                        nonce=None,
+                        constants=[],
+                        usage="binary",
+                    ),
+                ),
+                em.Binary(
+                    datatype=None,
+                    data=b"\x50\x60\x70\x80",
+                    other={"datatype": ["payload"]},
+                    encryption=[
+                        em.Binary.Encryption(
+                            algorithm="alxor",
+                            public_key=None,
+                            key=None,
+                            provider=None,
+                            mode=None,
+                            iv=None,
+                            seed=None,
+                            nonce=None,
+                            constants=[],
+                            usage="binary",
+                        ),
+                        em.Binary.Encryption(
+                            algorithm="RC4",
+                            public_key=None,
+                            key=None,
+                            provider=None,
+                            mode=None,
+                            iv=None,
+                            seed=None,
+                            nonce=None,
+                            constants=[],
+                            usage="binary",
+                        ),
+                    ],
+                ),
+            ],
+            ftp=[
+                em.FTP(
+                    username=None,
+                    password=None,
+                    hostname="somewhere",
+                    port=None,
+                    path=None,
+                    usage="c2",
+                )
+            ],
+            smtp=[
+                em.SMTP(
+                    username=None,
+                    password=None,
+                    hostname="here.com",
+                    port=None,
+                    mail_to=[],
+                    mail_from=None,
+                    subject=None,
+                    usage="upload",
+                )
+            ],
+            http=[
+                em.Http(
+                    uri=None,
+                    protocol="https",
+                    username=None,
+                    password=None,
+                    hostname="blarg.com",
+                    port=None,
+                    path="/malz",
+                    query=None,
+                    fragment=None,
+                    user_agent=None,
+                    method=None,
+                    headers=None,
+                    max_size=None,
+                    usage="c2",
+                )
+            ],
+            ssh=[
+                em.SSH(
+                    username=None,
+                    password=None,
+                    hostname="bad.malware",
+                    port=None,
+                    usage="download",
+                )
+            ],
+            proxy=[
+                em.Proxy(
+                    protocol=None,
+                    username=None,
+                    password=None,
+                    hostname="192.168.0.80",
+                    port=None,
+                    usage="tunnel",
+                )
+            ],
+            dns=[em.DNS(ip="123.21.21.21", port=None, usage="other")],
+            tcp=[
+                em.Connection(
+                    client_ip=None,
+                    client_port=None,
+                    server_ip="73.21.32.43",
+                    server_domain=None,
+                    server_port=None,
+                    usage="c2",
+                )
+            ],
+            udp=[
+                em.Connection(
+                    client_ip=None,
+                    client_port=None,
+                    server_ip="73.21.32.43",
+                    server_domain=None,
+                    server_port=None,
+                    usage="c2",
+                )
+            ],
+            encryption=[
+                em.Encryption(
+                    algorithm="alxor",
+                    public_key=None,
+                    key=None,
+                    provider=None,
+                    mode=None,
+                    iv=None,
+                    seed=None,
+                    nonce=None,
+                    constants=[],
+                    usage="binary",
+                )
+            ],
+            service=[
+                em.Service(
+                    dll=None,
+                    name="DeviceMonitorSvc",
+                    display_name="DeviceMonitorSvc",
+                    description="Device Monitor Service",
+                )
+            ],
+            cryptocurrency=[
+                em.Cryptocurrency(
+                    coin="APE",
+                    address="689fdh658790d6dr987yth84iyth7er8gtrfohyt9",
+                    ransom_amount=None,
+                    usage="miner",
+                )
+            ],
+            paths=[
+                em.Path(path="C:/Windows/system32", usage="install"),
+                em.Path(path="C:/user/USERNAME/xxxxx/xxxxx/", usage="logs"),
+                em.Path(path="\\here\\is\\some\\place", usage="install"),
+            ],
+            registry=[
+                em.Registry(
+                    key="HKLM_LOCAL_USER/some/location/to/key", usage="store_data"
+                ),
+                em.Registry(key="HKLM_LOCAL_USER/system/location", usage="read"),
+            ],
+        )
+        self.verify(
+            tmp,
+            {
+                "family": "scuba",
+                "version": "lotso_stuff",
+                "campaign_id": ["32"],
+                "identifier": ["uxuduxuduxuudux"],
+                "decoded_strings": ["there", "are", "some", "strings"],
+                "password": ["hunter2"],
+                "mutex": ["YEAH"],
+                "pipe": ["xiod"],
+                "sleep_delay": 45000,
+                "inject_exe": ["Teams.exe"],
+                "other": {"misc_data": {"nested": 5}},
+                "binaries": [
+                    {
+                        "data": b"\x10 0@",
+                        "other": {
+                            "datatype": ["payload"],
+                            "extension": [".invalid"],
+                            "label": ["xor 0x04 at 0x2130-0x2134"],
+                            "some_junk": [1, 2, 3, 4, 5, 6],
+                        },
+                        "encryption": {"algorithm": "alxor", "usage": "binary"},
+                    },
+                    {
+                        "data": b"P`p\x80",
+                        "other": {"datatype": ["payload"]},
+                        "encryption": [
+                            {"algorithm": "alxor", "usage": "binary"},
+                            {"algorithm": "RC4", "usage": "binary"},
+                        ],
+                    },
+                ],
+                "ftp": [{"hostname": "somewhere", "usage": "c2"}],
+                "smtp": [{"hostname": "here.com", "usage": "upload"}],
+                "http": [
+                    {
+                        "protocol": "https",
+                        "hostname": "blarg.com",
+                        "path": "/malz",
+                        "usage": "c2",
+                    }
+                ],
+                "ssh": [{"hostname": "bad.malware", "usage": "download"}],
+                "proxy": [{"hostname": "192.168.0.80", "usage": "tunnel"}],
+                "dns": [{"ip": "123.21.21.21", "usage": "other"}],
+                "tcp": [{"server_ip": "73.21.32.43", "usage": "c2"}],
+                "udp": [{"server_ip": "73.21.32.43", "usage": "c2"}],
+                "encryption": [{"algorithm": "alxor", "usage": "binary"}],
+                "service": [
+                    {
+                        "name": "DeviceMonitorSvc",
+                        "display_name": "DeviceMonitorSvc",
+                        "description": "Device Monitor Service",
+                    }
+                ],
+                "cryptocurrency": [
+                    {
+                        "coin": "APE",
+                        "address": "689fdh658790d6dr987yth84iyth7er8gtrfohyt9",
+                        "usage": "miner",
+                    }
+                ],
+                "paths": [
+                    {"path": "C:/Windows/system32", "usage": "install"},
+                    {"path": "C:/user/USERNAME/xxxxx/xxxxx/", "usage": "logs"},
+                    {"path": "\\here\\is\\some\\place", "usage": "install"},
+                ],
+                "registry": [
+                    {
+                        "key": "HKLM_LOCAL_USER/some/location/to/key",
+                        "usage": "store_data",
+                    },
+                    {"key": "HKLM_LOCAL_USER/system/location", "usage": "read"},
+                ],
+            },
+        )
+
+    def verify(self, in1, in2: Dict) -> Dict:
+        """Verify the returned data matches the schema."""
+        resp = collector._verify_response(in1)
+        self.assertEqual(resp, in2)
+
+
+class TestModelDict(unittest.TestCase):
+    def test_model_1(self):
         # dict example
         self.verify(
             {
@@ -41,7 +324,7 @@ class TestModel(unittest.TestCase):
             }
         )
 
-    def test_model_3(self):
+    def test_model_2(self):
         # dict example large
         self.maxDiff = None
 
@@ -125,10 +408,8 @@ class TestModel(unittest.TestCase):
             }
         )
 
-    def verify(self, config: Dict, exclude_defaults: bool = True) -> Dict:
+    def verify(self, config: Dict) -> Dict:
         """Verify the returned data matches the schema."""
-        model_dict = model.ExtractorModel.model_validate(config).model_dump(
-            exclude_defaults=exclude_defaults
-        )
-        self.assertEqual(model_dict, config)
-        return model_dict
+        tmp = model.ExtractorModel.model_validate(config)
+        resp = collector._verify_response(tmp)
+        self.assertEqual(resp, config)


### PR DESCRIPTION
The ExtractorModel isn't json compatible due to usage of 'bytes'. Pydantic will raise utf8 encoding issues when non unicode chars are present in the byte string.

This PR replaces the json dump logic with model_validate and model_dump. It is done twice to work around some pydantic behavior we observed where sets are only converted to lists on creation of the model.

A test case was added for the model and the verification code to prevent regressions.
