### PR TITLE
Add sleep_delay_jitter property

### DIFF
--- a/maco/model/model.py
+++ b/maco/model/model.py
@@ -186,6 +186,7 @@ class ExtractorModel(ForbidModel):
     mutex: List[str] = []  # mutex to prevent multiple instances
     pipe: List[str] = []  # pipe name used for communication
     sleep_delay: Optional[int] = None  # time to sleep/delay execution (milliseconds)
+    sleep_delay_jitter: Optional[int] = None  # maximum additional time applied to sleep_delay (milliseconds)
     inject_exe: List[str] = []  # name of executable to inject into
 
     # configuration or clustering/research data that doesnt fit the other fields

--- a/maco/model/model.py
+++ b/maco/model/model.py
@@ -186,7 +186,7 @@ class ExtractorModel(ForbidModel):
     mutex: List[str] = []  # mutex to prevent multiple instances
     pipe: List[str] = []  # pipe name used for communication
     sleep_delay: Optional[int] = None  # time to sleep/delay execution (milliseconds)
-    sleep_delay_jitter: Optional[int] = None  # maximum additional time applied to sleep_delay (milliseconds)
+    sleep_delay_jitter: Optional[int] = None  # additional time applied to sleep_delay (milliseconds). Jitter implementations can vary but usually it is a value from which a random number is generated and added/subtracted to the sleep_delay to make behaviour more unpredictable
     inject_exe: List[str] = []  # name of executable to inject into
 
     # configuration or clustering/research data that doesnt fit the other fields

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -42,6 +42,7 @@ class TestModelObject(unittest.TestCase):
             mutex=["YEAH"],
             pipe=["xiod"],
             sleep_delay=45000,
+            sleep_delay_jitter=2500,
             inject_exe=["Teams.exe"],
             other={"misc_data": {"nested": 5}},
             binaries=[
@@ -233,6 +234,7 @@ class TestModelObject(unittest.TestCase):
                 "mutex": ["YEAH"],
                 "pipe": ["xiod"],
                 "sleep_delay": 45000,
+                "sleep_delay_jitter": 2500,
                 "inject_exe": ["Teams.exe"],
                 "other": {"misc_data": {"nested": 5}},
                 "binaries": [


### PR DESCRIPTION
Small update to add a jitter property. 

I would imagine this would usually be the maximum amount of time added to the sleep delay but there could be cases where the jitter is represented as a config value from which the additional sleep time is calculated from. 