### PR TITLE
feat: test with python 3.11 and 3.12

### DIFF
--- a/pipelines/publish.yaml
+++ b/pipelines/publish.yaml
@@ -20,12 +20,12 @@ jobs:
         python.version: '3.8'
       Python39:
         python.version: '3.9'
-      # Python310:
-      #   python.version: '3.10'
-      # Python311:
-      #   python.version: '3.11'
-      # Python312:
-      #   python.version: '3.12'
+      Python310:
+        python.version: '3.10'
+      Python311:
+        python.version: '3.11'
+      Python312:
+        python.version: '3.12'
   steps:
   - task: UsePythonVersion@0
     displayName: 'Use Python $(python.version)'

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py38,py39,py311,py312
+envlist = py38,py39,py310,py311,py312
 [testenv]
 # install testing framework
 deps =

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py38,py39
+envlist = py38,py39,py311,py312
 [testenv]
 # install testing framework
 deps =


### PR DESCRIPTION
Ensure that tox tests maco with python 3.11 and 3.12 to verify compatibility.

I'm seeing test failures with rat_king_parser locally on 3.11 even with #59.