### PR TITLE
Feat/performance

### DIFF
--- a/demo_extractors/complex/complex.py
+++ b/demo_extractors/complex/complex.py
@@ -1,9 +1,8 @@
 from io import BytesIO
 from typing import List, Optional
 
-from maco import extractor, model, yara
-
 from demo_extractors.complex import complex_utils
+from maco import extractor, model, yara
 
 
 class Complex(extractor.Extractor):

--- a/demo_extractors/limit_other.py
+++ b/demo_extractors/limit_other.py
@@ -23,6 +23,10 @@ class LimitOther(extractor.Extractor):
         """
 
     def run(self, stream: BytesIO, matches: List[yara.Match]) -> Optional[model.ExtractorModel]:
+        # import httpx at runtime so we can test that requirements.txt is installed dynamically without breaking
+        # the tests that do direct importing
+        import httpx
+
         # use a custom model that inherits from ExtractorModel
         # this model defines what can go in the 'other' dict
         tmp = shared.MyCustomModel(family="specify_other")

--- a/demo_extractors/limit_other.py
+++ b/demo_extractors/limit_other.py
@@ -1,9 +1,8 @@
 from io import BytesIO
 from typing import Dict, List, Optional
 
-from maco import extractor, model, yara
-
 from demo_extractors import shared
+from maco import extractor, model, yara
 
 
 class LimitOther(extractor.Extractor):

--- a/demo_extractors/requirements.txt
+++ b/demo_extractors/requirements.txt
@@ -1,0 +1,1 @@
+pycryptodome

--- a/demo_extractors/requirements.txt
+++ b/demo_extractors/requirements.txt
@@ -1,1 +1,1 @@
-pycryptodome
+httpx

--- a/demo_extractors/requirements.txt
+++ b/demo_extractors/requirements.txt
@@ -1,1 +1,2 @@
 pycryptodome
+maco

--- a/demo_extractors/requirements.txt
+++ b/demo_extractors/requirements.txt
@@ -1,2 +1,1 @@
 pycryptodome
-maco

--- a/demo_extractors/shared.py
+++ b/demo_extractors/shared.py
@@ -1,4 +1,5 @@
 from typing import Optional
+
 import pydantic
 
 from maco import model

--- a/maco/base_test.py
+++ b/maco/base_test.py
@@ -54,18 +54,20 @@ class BaseTest(unittest.TestCase):
         resp = self.c.extract(stream, self.name)
         return resp
 
-    def _get_location(self) -> str:
+    @classmethod
+    def _get_location(cls) -> str:
         """Return path to child class that implements this class."""
         # import child module
-        module = type(self).__module__
+        module = cls.__module__
         i = importlib.import_module(module)
         # get location to child module
         return i.__file__
 
-    def load_cart(self, filepath: str) -> io.BytesIO:
+    @classmethod
+    def load_cart(cls, filepath: str) -> io.BytesIO:
         """Load and unneuter a test file (likely malware) into memory for processing."""
         # it is nice if we can load files relative to whatever is implementing base_test
-        dirpath = os.path.split(self._get_location())[0]
+        dirpath = os.path.split(cls._get_location())[0]
         # either filepath is absolute, or should be loaded relative to child of base_test
         filepath = os.path.join(dirpath, filepath)
         if not os.path.isfile(filepath):

--- a/maco/base_test.py
+++ b/maco/base_test.py
@@ -32,14 +32,19 @@ class BaseTest(unittest.TestCase):
     # I recommend something like os.path.join(__file__, "../../extractors")
     # if your extractors are in a folder 'extractors' next to a folder of tests
     path: str = None
+    create_venv: bool=False
 
-    def setUp(self) -> None:
-        if not self.name or not self.path:
+    @classmethod
+    def setUpClass(cls) -> None:
+        if not cls.name or not cls.path:
             raise Exception("name and path must be set")
-        self.c = collector.Collector(self.path, include=[self.name])
+        cls.c = collector.Collector(cls.path, include=[cls.name], create_venv=cls.create_venv)
+        return super().setUpClass()
+
+    def test_metadata(self):
+        """Require extractor to be loadable and valid."""
         self.assertIn(self.name, self.c.extractors)
         self.assertEqual(len(self.c.extractors), 1)
-        return super().setUp()
 
     def extract(self, stream):
         """Return results for running extractor over stream, including yara check."""

--- a/maco/base_test.py
+++ b/maco/base_test.py
@@ -41,7 +41,7 @@ class BaseTest(unittest.TestCase):
         cls.c = collector.Collector(cls.path, include=[cls.name], create_venv=cls.create_venv)
         return super().setUpClass()
 
-    def test_metadata(self):
+    def test_default_metadata(self):
         """Require extractor to be loadable and valid."""
         self.assertIn(self.name, self.c.extractors)
         self.assertEqual(len(self.c.extractors), 1)

--- a/maco/cli.py
+++ b/maco/cli.py
@@ -179,7 +179,7 @@ def main():
     parser.add_argument(
         "--create_venv",
         action="store_true",
-        help="Creates venvs for every requirements.txt found (only applies when extractor path is a directory)",
+        help="Creates venvs for every requirements.txt found (only applies when extractor path is a directory). This runs much slower than the alternative but may be necessary when there are many extractors with conflicting dependencies.",
     )
     args = parser.parse_args()
     inc = args.include.split(",") if args.include else []

--- a/maco/extractor.py
+++ b/maco/extractor.py
@@ -51,14 +51,14 @@ class Extractor:
         # check yara rules conform to expected structure
         # we throw away these compiled rules as we need all rules in system compiled together
         try:
-            rules = yara.compile(source=self.yara_rule)
+            self.yara_compiled = yara.compile(source=self.yara_rule)
         except yara.SyntaxError as e:
             raise InvalidExtractor(f"{self.name} - invalid yara rule") from e
         # need to track which plugin owns the rules
-        self.yara_rule_names = [x.identifier for x in rules]
-        if not len(list(rules)):
+        self.yara_rule_names = [x.identifier for x in self.yara_compiled]
+        if not len(list(self.yara_compiled)):
             raise InvalidExtractor(f"{name} must define at least one yara rule")
-        for x in rules:
+        for x in self.yara_compiled:
             if x.is_global:
                 raise InvalidExtractor(f"{x.identifier} yara rule must not be global")
 

--- a/maco/utils.py
+++ b/maco/utils.py
@@ -311,7 +311,7 @@ def register_extractors(
     package_name = os.path.basename(current_directory)
     parent_directory = os.path.dirname(current_directory)
     symlink = None
-    if package_name in sys.modules:
+    if venvs and package_name in sys.modules:
         # this may happen as part of testing if some part of the extractor code was directly imported
         logger.warning(f"Looks like {package_name} is already loaded. "
                        "If your maco extractor overlaps an existing package name this could cause problems.")

--- a/maco/utils.py
+++ b/maco/utils.py
@@ -312,9 +312,9 @@ def _create_virtual_environments(directories: List[str], python_version: str, lo
                     if b"is being installed using the legacy" in p.stderr:
                         # Ignore these types of errors
                         continue
-                    logger.error(f"Error installing into venv:\n{p.stderr.decode()}")
+                    logger.error(f"Error installing into venv:\n{p.stdout.decode()}\n{p.stderr.decode()}")
                 else:
-                    logger.debug(f"Installed dependencies into venv:\n{p.stdout.decode()}")
+                    logger.debug(f"Installed dependencies into venv:\n{p.stdout.decode()}\n{p.stderr.decode()}")
                     venvs.append(venv_path)
 
                 # Cleanup any build directories that are the product of package installation

--- a/maco/utils.py
+++ b/maco/utils.py
@@ -214,7 +214,8 @@ def _install_required_packages(directories: List[str], logger: Logger):
             req_files = list({"requirements.txt", "pyproject.toml"}.intersection(set(os.listdir(dir))))
             if req_files:
                 # Install/Update the packages in the environment
-                install_command = PIP_CMD.split(" ") + ["install", "-U"]
+                # Due to issues installing latest maco during development, does not install latest packages
+                install_command = PIP_CMD.split(" ") + ["install"]
                 # Update the pip install command depending on where the dependencies are coming from
                 if "requirements.txt" in req_files:
                     # Perform a pip install using the requirements flag
@@ -280,7 +281,8 @@ def _create_virtual_environments(directories: List[str], python_version: str, lo
                     subprocess.run(cmd.split(" ") + [venv_path], capture_output=True, env=env)
 
                 # Install/Update the packages in the environment
-                install_command = PIP_CMD.split(" ") + ["install", "-U"]
+                # Due to issues installing latest maco during development, does not install latest packages
+                install_command = PIP_CMD.split(" ") + ["install"]
 
                 # Update the pip install command depending on where the dependencies are coming from
                 if "requirements.txt" in req_files:

--- a/maco/utils.py
+++ b/maco/utils.py
@@ -455,7 +455,6 @@ def import_extractors(
     *,
     root_directory: str,
     scanner: yara.Rules,
-    use_venv: bool,
     create_venv: bool,
     logger: Logger,
     python_version: str = f"{sys.version_info.major}.{sys.version_info.minor}.{sys.version_info.micro}",
@@ -466,12 +465,11 @@ def import_extractors(
     logger.debug(extractor_files)
 
     venvs = []
-    if not use_venv:
+    if not create_venv:
         # install packages into current environment
         _install_required_packages(extractor_dirs, logger)
-    elif create_venv:
-        venvs = _create_virtual_environments(extractor_dirs, python_version, logger)
     else:
+        venvs = _create_virtual_environments(extractor_dirs, python_version, logger)
         # Look for pre-existing virtual environments, if any
         logger.info("Checking for pre-existing virtual environment(s)..")
         venvs = [

--- a/maco/utils.py
+++ b/maco/utils.py
@@ -443,14 +443,14 @@ def run_extractor(
 ) -> Union[Dict[str, dict], model.ExtractorModel]:
     """Runs the maco extractor against sample either in current process or child process."""
     if not venv:
-        # dynamic import and execute of the extractor
         key = f"{module_name}_{extractor_class}"
         if key not in _loaded_extractors:
-            # run the maco extractor in current process (fast)
+            # dynamic import of extractor
             mod = importlib.import_module(module_name)
             extractor_cls = mod.__getattribute__(extractor_class)
             extractor = extractor_cls()
         else:
+            # retrieve cached extractor
             extractor = _loaded_extractors[key]
         if extractor.yara_compiled:
             matches = extractor.yara_compiled.match(sample_path)

--- a/tests/benchmark.py
+++ b/tests/benchmark.py
@@ -35,6 +35,6 @@ def make():
 
 if __name__ == "__main__":
     print("maco hot loading and venv isolation")
-    print(timeit.timeit("tc.test_auto_extract()", setup="from __main__ import make; tc=make()", number=10))
+    print(timeit.timeit("tc.test_auto_extract()", setup="from __main__ import make; tc=make()", number=100))
     print("bypass hack")
-    print(timeit.timeit("tc.test_manual_extract()", setup="from __main__ import make; tc=make()", number=10))
+    print(timeit.timeit("tc.test_manual_extract()", setup="from __main__ import make; tc=make()", number=100))

--- a/tests/benchmark.py
+++ b/tests/benchmark.py
@@ -1,10 +1,11 @@
-import timeit
+import cProfile
 import io
 import os
+import timeit
 
 from demo_extractors.complex import complex, complex_utils
 from maco import base_test
-import cProfile
+
 instance = complex.Complex()
 
 class TestComplex(base_test.BaseTest):

--- a/tests/benchmark.py
+++ b/tests/benchmark.py
@@ -59,7 +59,7 @@ def make_venv():
 if __name__ == "__main__":
     trials = 100
     print(f"num trials: {trials}")
-    print("bypass hack - synthetic comparison (directly import and execute extractor) ")
+    print("synthetic comparison (directly import and execute extractor)")
     print(timeit.timeit("tc.test_manual_extract()", setup="from __main__ import make; tc=make()", number=trials))
     print("maco no venv isolation")
     print(timeit.timeit("tc.test_auto_extract()", setup="from __main__ import make; tc=make()", number=trials))

--- a/tests/benchmark.py
+++ b/tests/benchmark.py
@@ -1,0 +1,40 @@
+import timeit
+import io
+import os
+
+from demo_extractors.complex import complex, complex_utils
+from maco import base_test
+import cProfile
+instance = complex.Complex()
+
+class TestComplex(base_test.BaseTest):
+    name = "Complex"
+    path = os.path.join(__file__, "../../demo_extractors")
+
+
+    def test_auto_extract(self):
+        """Tests that we can run an extractor through maco."""
+        inputs = self.load_cart("data/trigger_complex.txt.cart")
+        inputs.seek(0)
+        ret = self.extract(inputs)
+        self.assertEqual(ret["family"], "complex")
+        self.assertEqual(ret["version"], "5")
+
+    def test_manual_extract(self):
+        """Tests that we can run an extractor through maco."""
+        inputs = self.load_cart("data/trigger_complex.txt.cart")
+        inputs.seek(0)
+        result = instance.run(inputs, [])
+        self.assertEqual(result.family, "complex")
+
+def make():
+    tc = TestComplex()
+    tc.setUp()
+    return tc
+
+
+if __name__ == "__main__":
+    print("maco hot loading and venv isolation")
+    print(timeit.timeit("tc.test_auto_extract()", setup="from __main__ import make; tc=make()", number=10))
+    print("bypass hack")
+    print(timeit.timeit("tc.test_manual_extract()", setup="from __main__ import make; tc=make()", number=10))

--- a/tests/benchmark.py
+++ b/tests/benchmark.py
@@ -44,11 +44,13 @@ class TestComplexVenv(base_test.BaseTest):
         self.assertEqual(ret["version"], "5")
 
 def make():
+    TestComplex.setUpClass()
     tc = TestComplex()
     tc.setUp()
     return tc
 
 def make_venv():
+    TestComplexVenv.setUpClass()
     tc = TestComplexVenv()
     tc.setUp()
     return tc
@@ -56,8 +58,8 @@ def make_venv():
 
 if __name__ == "__main__":
     print("bypass hack - synthetic comparison (directly import and execute extractor)")
-    print(timeit.timeit("tc.test_manual_extract()", setup="from __main__ import make; tc=make()", number=1000))
+    print(timeit.timeit("tc.test_manual_extract()", setup="from __main__ import make; tc=make()", number=10))
     print("maco no venv isolation")
-    print(timeit.timeit("tc.test_auto_extract()", setup="from __main__ import make; tc=make()", number=1000))
+    print(timeit.timeit("tc.test_auto_extract()", setup="from __main__ import make; tc=make()", number=10))
     print("maco venv isolation")
-    print(timeit.timeit("tc.test_auto_extract()", setup="from __main__ import make; tc=make_venv()", number=1000))
+    print(timeit.timeit("tc.test_auto_extract()", setup="from __main__ import make_venv; tc=make_venv()", number=10))

--- a/tests/benchmark.py
+++ b/tests/benchmark.py
@@ -48,9 +48,16 @@ def make():
     tc.setUp()
     return tc
 
+def make_venv():
+    tc = TestComplexVenv()
+    tc.setUp()
+    return tc
+
 
 if __name__ == "__main__":
-    print("maco hot loading and venv isolation")
-    print(timeit.timeit("tc.test_auto_extract()", setup="from __main__ import make; tc=make()", number=1000))
-    print("bypass hack")
+    print("bypass hack - synthetic comparison (directly import and execute extractor)")
     print(timeit.timeit("tc.test_manual_extract()", setup="from __main__ import make; tc=make()", number=1000))
+    print("maco no venv isolation")
+    print(timeit.timeit("tc.test_auto_extract()", setup="from __main__ import make; tc=make()", number=1000))
+    print("maco venv isolation")
+    print(timeit.timeit("tc.test_auto_extract()", setup="from __main__ import make; tc=make_venv()", number=1000))

--- a/tests/benchmark.py
+++ b/tests/benchmark.py
@@ -9,9 +9,10 @@ from maco import base_test
 instance = complex.Complex()
 
 class TestComplex(base_test.BaseTest):
+    """Test extractors work under default conditions."""
     name = "Complex"
     path = os.path.join(__file__, "../../demo_extractors")
-
+    create_venv=False
 
     def test_auto_extract(self):
         """Tests that we can run an extractor through maco."""
@@ -27,6 +28,20 @@ class TestComplex(base_test.BaseTest):
         inputs.seek(0)
         result = instance.run(inputs, [])
         self.assertEqual(result.family, "complex")
+
+class TestComplexVenv(base_test.BaseTest):
+    """Test extractors work when run with virtual environments."""
+    name = "Complex"
+    path = os.path.join(__file__, "../../demo_extractors")
+    create_venv=True
+
+    def test_auto_extract(self):
+        """Tests that we can run an extractor through maco."""
+        inputs = self.load_cart("data/trigger_complex.txt.cart")
+        inputs.seek(0)
+        ret = self.extract(inputs)
+        self.assertEqual(ret["family"], "complex")
+        self.assertEqual(ret["version"], "5")
 
 def make():
     tc = TestComplex()

--- a/tests/benchmark.py
+++ b/tests/benchmark.py
@@ -57,9 +57,11 @@ def make_venv():
 
 
 if __name__ == "__main__":
-    print("bypass hack - synthetic comparison (directly import and execute extractor)")
-    print(timeit.timeit("tc.test_manual_extract()", setup="from __main__ import make; tc=make()", number=10))
+    trials = 100
+    print(f"num trials: {trials}")
+    print("bypass hack - synthetic comparison (directly import and execute extractor) ")
+    print(timeit.timeit("tc.test_manual_extract()", setup="from __main__ import make; tc=make()", number=trials))
     print("maco no venv isolation")
-    print(timeit.timeit("tc.test_auto_extract()", setup="from __main__ import make; tc=make()", number=10))
+    print(timeit.timeit("tc.test_auto_extract()", setup="from __main__ import make; tc=make()", number=trials))
     print("maco venv isolation")
-    print(timeit.timeit("tc.test_auto_extract()", setup="from __main__ import make_venv; tc=make_venv()", number=10))
+    print(timeit.timeit("tc.test_auto_extract()", setup="from __main__ import make_venv; tc=make_venv()", number=trials))

--- a/tests/benchmark.py
+++ b/tests/benchmark.py
@@ -36,6 +36,6 @@ def make():
 
 if __name__ == "__main__":
     print("maco hot loading and venv isolation")
-    print(timeit.timeit("tc.test_auto_extract()", setup="from __main__ import make; tc=make()", number=100))
+    print(timeit.timeit("tc.test_auto_extract()", setup="from __main__ import make; tc=make()", number=1000))
     print("bypass hack")
-    print(timeit.timeit("tc.test_manual_extract()", setup="from __main__ import make; tc=make()", number=100))
+    print(timeit.timeit("tc.test_manual_extract()", setup="from __main__ import make; tc=make()", number=1000))

--- a/tests/test_base_test.py
+++ b/tests/test_base_test.py
@@ -56,18 +56,3 @@ class TestComplexVenv(base_test.BaseTest):
         ret = self.extract(self.load_cart("data/trigger_complex.txt.cart"))
         self.assertEqual(ret["family"], "complex")
         self.assertEqual(ret["version"], "5")
-
-    def test_subfunction(self):
-        """Tests that we can import directly from the extractor module and run a function."""
-        self.assertEqual(complex_utils.getdata(), {"result": 5})
-
-    def test_manual_extract(self):
-        """Tests that we can run an extractor through maco."""
-        ref = complex.Complex
-        self.assertGreater(len(ref.yara_rule), 100)
-        instance = complex.Complex()
-        self.assertGreater(len(instance.yara_rule), 100)
-
-        data = io.BytesIO(b"my malwarez")
-        result = instance.run(data, [])
-        self.assertEqual(result.family, "complex")

--- a/tests/test_base_test.py
+++ b/tests/test_base_test.py
@@ -19,9 +19,11 @@ class TestLimitOther(base_test.BaseTest):
         self.assertEqual(ret["family"], "specify_other")
         self.assertEqual(ret["campaign_id"], ["12345"])
 
+
 class TestComplex(base_test.BaseTest):
     name = "Complex"
     path = os.path.join(__file__, "../../demo_extractors")
+    create_venv = False
 
     def test_extract(self):
         """Tests that we can run an extractor through maco."""
@@ -43,3 +45,30 @@ class TestComplex(base_test.BaseTest):
         data = io.BytesIO(b"my malwarez")
         result = instance.run(data, [])
         self.assertEqual(result.family, "complex")
+
+# FUTURE requires import PR to be merged as this installs the latest maco from pypi into the venv
+# class TestComplexVenv(base_test.BaseTest):
+#     name = "Complex"
+#     path = os.path.join(__file__, "../../demo_extractors")
+#     create_venv = True
+
+#     def test_extract(self):
+#         """Tests that we can run an extractor through maco."""
+#         ret = self.extract(self.load_cart("data/trigger_complex.txt.cart"))
+#         self.assertEqual(ret["family"], "complex")
+#         self.assertEqual(ret["version"], "5")
+
+#     def test_subfunction(self):
+#         """Tests that we can import directly from the extractor module and run a function."""
+#         self.assertEqual(complex_utils.getdata(), {"result": 5})
+
+#     def test_manual_extract(self):
+#         """Tests that we can run an extractor through maco."""
+#         ref = complex.Complex
+#         self.assertGreater(len(ref.yara_rule), 100)
+#         instance = complex.Complex()
+#         self.assertGreater(len(instance.yara_rule), 100)
+
+#         data = io.BytesIO(b"my malwarez")
+#         result = instance.run(data, [])
+#         self.assertEqual(result.family, "complex")

--- a/tests/test_base_test.py
+++ b/tests/test_base_test.py
@@ -21,6 +21,7 @@ class TestLimitOther(base_test.BaseTest):
 
 
 class TestComplex(base_test.BaseTest):
+    """Test that complex extractor can be used in base environment."""
     name = "Complex"
     path = os.path.join(__file__, "../../demo_extractors")
     create_venv = False
@@ -47,6 +48,7 @@ class TestComplex(base_test.BaseTest):
         self.assertEqual(result.family, "complex")
 
 class TestComplexVenv(base_test.BaseTest):
+    """Test that complex extractor can be used in full venv isolation."""
     name = "Complex"
     path = os.path.join(__file__, "../../demo_extractors")
     create_venv = True

--- a/tests/test_base_test.py
+++ b/tests/test_base_test.py
@@ -46,29 +46,28 @@ class TestComplex(base_test.BaseTest):
         result = instance.run(data, [])
         self.assertEqual(result.family, "complex")
 
-# FUTURE requires import PR to be merged as this installs the latest maco from pypi into the venv
-# class TestComplexVenv(base_test.BaseTest):
-#     name = "Complex"
-#     path = os.path.join(__file__, "../../demo_extractors")
-#     create_venv = True
+class TestComplexVenv(base_test.BaseTest):
+    name = "Complex"
+    path = os.path.join(__file__, "../../demo_extractors")
+    create_venv = True
 
-#     def test_extract(self):
-#         """Tests that we can run an extractor through maco."""
-#         ret = self.extract(self.load_cart("data/trigger_complex.txt.cart"))
-#         self.assertEqual(ret["family"], "complex")
-#         self.assertEqual(ret["version"], "5")
+    def test_extract(self):
+        """Tests that we can run an extractor through maco."""
+        ret = self.extract(self.load_cart("data/trigger_complex.txt.cart"))
+        self.assertEqual(ret["family"], "complex")
+        self.assertEqual(ret["version"], "5")
 
-#     def test_subfunction(self):
-#         """Tests that we can import directly from the extractor module and run a function."""
-#         self.assertEqual(complex_utils.getdata(), {"result": 5})
+    def test_subfunction(self):
+        """Tests that we can import directly from the extractor module and run a function."""
+        self.assertEqual(complex_utils.getdata(), {"result": 5})
 
-#     def test_manual_extract(self):
-#         """Tests that we can run an extractor through maco."""
-#         ref = complex.Complex
-#         self.assertGreater(len(ref.yara_rule), 100)
-#         instance = complex.Complex()
-#         self.assertGreater(len(instance.yara_rule), 100)
+    def test_manual_extract(self):
+        """Tests that we can run an extractor through maco."""
+        ref = complex.Complex
+        self.assertGreater(len(ref.yara_rule), 100)
+        instance = complex.Complex()
+        self.assertGreater(len(instance.yara_rule), 100)
 
-#         data = io.BytesIO(b"my malwarez")
-#         result = instance.run(data, [])
-#         self.assertEqual(result.family, "complex")
+        data = io.BytesIO(b"my malwarez")
+        result = instance.run(data, [])
+        self.assertEqual(result.family, "complex")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,6 +1,6 @@
 import os
-
 import unittest
+
 from maco import cli
 
 

--- a/tests/test_detection.py
+++ b/tests/test_detection.py
@@ -1,6 +1,7 @@
 import os
-import pytest
 import sys
+
+import pytest
 
 from maco.collector import Collector
 
@@ -105,9 +106,9 @@ def test_public_projects(repository_url: str, extractors: list, python_minor: in
     # Ensure that any changes we make doesn't break usage of public projects
     # which can affect downstream systems using like library (ie. Assemblyline)
     import sys
+    from tempfile import TemporaryDirectory
 
     from git import Repo
-    from tempfile import TemporaryDirectory
 
     if sys.version_info >= (3, python_minor):
         with TemporaryDirectory() as working_dir:
@@ -123,8 +124,9 @@ def test_public_projects(repository_url: str, extractors: list, python_minor: in
 
 
 def test_module_confusion():
-    from tempfile import TemporaryDirectory
     import shutil
+    from tempfile import TemporaryDirectory
+
     import git
 
     # Directories that have the same name as the Python module, shouldn't cause confusion on loading the right module

--- a/tox.ini
+++ b/tox.ini
@@ -7,4 +7,4 @@ deps =
     -r requirements.txt
     -r tests/requirements.txt
 # run the tests
-commands = python -m pytest -p no:cacheprovider --durations=10 -ra -q -k "not git and not extractors" -vv -W ignore::DeprecationWarning
+commands = python -m pytest tests/ -p no:cacheprovider --durations=10 -ra -q -k "not git and not extractors" -vv -W ignore::DeprecationWarning


### PR DESCRIPTION
This PR improves performance of the 'non-venv' path in Maco by 85x. This is primarily due to process reuse - not restarting the python interpreter for each analysis task. I focused on analysis execution times, not startup time.

I've added `tests/benchmark.py` to show the performance improvement. There is still room for improvement compared to the synthetic case, but the benchmark shows that the non-venv implementation is around 85x faster than the venv implementation.

The non-venv option can only be used if all targeted extractors have a compatible set of requirements between them - no conflicting package versions.

```
(maco) seb@seb:~/work/Maco$ python tests/benchmark.py 
num trials: 1000
results are number of seconds to execute total number of trials
synthetic comparison (directly import and execute extractor)
0.2291743489995497
maco no venv isolation
8.69246902299983
maco venv isolation
754.8817715150008
```

I briefly attempted to make the venv path use a multiprocess 'spawn' of Python with an alternate virtual environment in the hopes this would speed up execution, but yara-x seems to deadlock during compile of yara rules. Likely performance improvements for venv will require an overhaul of the dynamic python script to run in a client/server or daemon mode (rather than shutting down after each job). Given the complexity of this path already, I decided not to attempt this. A simple code path for non-venv was desirable for maintenance and complexity reasons.

Changes:

* requirements are installed without upgrading existing ones. TODO verify if required in final PR.
* requirements are automatically installed to virtual environment or current environment, depending on create_venv choice.
* `create_venv=True` argument is now required if you want to use independent virtual environments at all.
* Sorted imports across the board with isort
* added demo extractor that uses external library - for test case of installing requirements.txt automatically
* base_test supports create_venv=True/False
* remove fallback for pip, as uv is already required in requirements.txt

Following notes are for `create_venv=False`

* compile yara rules when extractor is initialised, not at runtime of job (yarax is slower to compile rules as it performs more optimisation)
* cache extractors once initialised as they should be reusable between different samples
* less use of subprocess or multiprocessing, instead the current thread is used for importing and execution of extractors
