### PR TITLE
Add automated linting

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Maco - Malware config extractor framework
 
-## Maco is a framework for ***ma***lware ***co***nfig extractors.
+## Maco is a framework for **_ma_**lware **_co_**nfig extractors.
 
 It aims to solve two problems:
 
@@ -234,3 +234,15 @@ run Complex extractor from rules ['ComplexAlt']
 The demo extractors are designed to trigger when run over the '`demo_extractors`' folder.
 
 e.g. `maco demo_extractors demo_extractors`
+
+# Contributions
+
+Please use ruff to format and lint PRs. This may be the cause of PR test failures.
+
+Ruff will attempt to fix most issues, but some may require manual resolution.
+
+```
+pip install ruff
+ruff format
+ruff check --fix
+```

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Maco - Malware config extractor framework
 
-## Maco is a framework for **_ma_**lware **_co_**nfig extractors.
+## Maco is a framework for <ins>ma</ins>lware <ins>co</ins>nfig extractors.
 
 It aims to solve two problems:
 

--- a/demo_extractors/elfy.py
+++ b/demo_extractors/elfy.py
@@ -1,5 +1,5 @@
 from io import BytesIO
-from typing import Dict, List, Optional
+from typing import List, Optional
 
 from maco import extractor, model, yara
 

--- a/demo_extractors/limit_other.py
+++ b/demo_extractors/limit_other.py
@@ -1,5 +1,5 @@
 from io import BytesIO
-from typing import Dict, List, Optional
+from typing import List, Optional
 
 from demo_extractors import shared
 from maco import extractor, model, yara
@@ -26,6 +26,10 @@ class LimitOther(extractor.Extractor):
         # import httpx at runtime so we can test that requirements.txt is installed dynamically without breaking
         # the tests that do direct importing
         import httpx
+
+        # use httpx so it doesn't get deleted by auto linter
+        if not httpx.__name__:
+            raise Exception("wow I really want to use this library in a useful way")
 
         # use a custom model that inherits from ExtractorModel
         # this model defines what can go in the 'other' dict

--- a/demo_extractors/nothing.py
+++ b/demo_extractors/nothing.py
@@ -1,5 +1,5 @@
 from io import BytesIO
-from typing import Dict, List, Optional
+from typing import List, Optional
 
 from maco import extractor, model, yara
 

--- a/maco/base_test.py
+++ b/maco/base_test.py
@@ -32,7 +32,7 @@ class BaseTest(unittest.TestCase):
     # I recommend something like os.path.join(__file__, "../../extractors")
     # if your extractors are in a folder 'extractors' next to a folder of tests
     path: str = None
-    create_venv: bool=False
+    create_venv: bool = False
 
     @classmethod
     def setUpClass(cls) -> None:

--- a/maco/cli.py
+++ b/maco/cli.py
@@ -1,4 +1,5 @@
 """CLI example of how extractors can be executed."""
+
 import argparse
 import base64
 import binascii
@@ -150,6 +151,7 @@ def process_filesystem(
         logger.info(f"{num_analysed} analysed, {num_hits} hits, {num_extracted} extracted")
     return num_analysed, num_hits, num_extracted
 
+
 def main():
     parser = argparse.ArgumentParser(description="Run extractors over samples.")
     parser.add_argument("extractors", type=str, help="path to extractors")
@@ -228,7 +230,7 @@ def main():
         pretty=args.pretty,
         force=args.force,
         include_base64=args.base64,
-        create_venv=args.create_venv
+        create_venv=args.create_venv,
     )
 
 

--- a/maco/cli.py
+++ b/maco/cli.py
@@ -165,7 +165,8 @@ def main():
     parser.add_argument(
         "--base64",
         action="store_true",
-        help="Include base64 encoded binary data in output (can be large, consider printing to file rather than console)",
+        help="Include base64 encoded binary data in output "
+        "(can be large, consider printing to file rather than console)",
     )
     parser.add_argument("--logfile", type=str, help="file to log output")
     parser.add_argument("--include", type=str, help="comma separated extractors to run")
@@ -179,7 +180,9 @@ def main():
     parser.add_argument(
         "--create_venv",
         action="store_true",
-        help="Creates venvs for every requirements.txt found (only applies when extractor path is a directory). This runs much slower than the alternative but may be necessary when there are many extractors with conflicting dependencies.",
+        help="Creates venvs for every requirements.txt found (only applies when extractor path is a directory). "
+        "This runs much slower than the alternative but may be necessary "
+        "when there are many extractors with conflicting dependencies.",
     )
     args = parser.parse_args()
     inc = args.include.split(",") if args.include else []

--- a/maco/collector.py
+++ b/maco/collector.py
@@ -4,6 +4,7 @@ import inspect
 import logging
 import logging.handlers
 import os
+import sys
 from multiprocessing import Manager, Process, Queue
 from tempfile import NamedTemporaryFile
 from types import ModuleType
@@ -48,6 +49,15 @@ class Collector:
         create_venv: bool = False,
     ):
         """Discover and load extractors from file system."""
+        # maco requires the extractor to be imported directly, so ensure they are available on the path
+        full_path_extractors = os.path.abspath(path_extractors)
+        full_path_above_extractors = os.path.dirname(full_path_extractors)
+        # Modify the PATH so we can recognize this new package on import
+        if full_path_extractors not in sys.path:
+            sys.path.insert(1, full_path_extractors)
+        if full_path_above_extractors not in sys.path:
+            sys.path.insert(1, full_path_above_extractors)
+
         path_extractors = os.path.realpath(path_extractors)
         self.path: str = path_extractors
         self.extractors: Dict[str, Dict[str, str]] = {}

--- a/maco/collector.py
+++ b/maco/collector.py
@@ -89,7 +89,7 @@ class Collector:
 
             # multiprocess logging is awkward - set up a queue to ensure we can log
             logging_queue = Queue()
-            queue_handler = logging.handlers.QueueListener(logging_queue,*logging.getLogger().handlers)
+            queue_handler = logging.handlers.QueueListener(logging_queue, *logging.getLogger().handlers)
             queue_handler.start()
 
             # Find the extractors within the given directory

--- a/maco/model/__init__.py
+++ b/maco/model/__init__.py
@@ -1,1 +1,1 @@
-from maco.model.model import *
+from maco.model.model import * # noqa: F403

--- a/maco/model/__init__.py
+++ b/maco/model/__init__.py
@@ -1,1 +1,1 @@
-from maco.model.model import * # noqa: F403
+from maco.model.model import *  # noqa: F403

--- a/maco/model/model.py
+++ b/maco/model/model.py
@@ -59,31 +59,48 @@ class CategoryEnum(str, Enum):
     # Malware related to an Advanced Persistent Threat (APT) group.
     apt = "apt"
 
-    # A backdoor Trojan gives malicious users remote control over the infected computer. They enable the author to do anything they wish on the infected computer including sending, receiving, launching and deleting files, displaying data and rebooting the computer. Backdoor Trojans are often used to unite a group of victim computers to form a botnet or zombie network that can be used for criminal purposes.
+    # A backdoor Trojan gives malicious users remote control over the infected computer.
+    # They enable the author to do anything they wish on the infected computer including
+    # sending, receiving, launching and deleting files, displaying data and rebooting the computer.
+    # Backdoor Trojans are often used to unite a group of victim computers to form a botnet or
+    # zombie network that can be used for criminal purposes.
     backdoor = "backdoor"
 
-    # Trojan Banker programs are designed to steal your account data for online banking systems, e-payment systems and credit or debit cards.
+    # Trojan Banker programs are designed to steal your account data for online banking systems,
+    # e-payment systems and credit or debit cards.
     banker = "banker"
 
-    # A malware variant that modifies the boot sectors of a hard drive, including the Master Boot Record (MBR) and Volume Boot Record (VBR).
+    # A malware variant that modifies the boot sectors of a hard drive, including the Master Boot Record (MBR)
+    # and Volume Boot Record (VBR).
     bootkit = "bootkit"
 
-    # A malicious bot is self-propagating malware designed to infect a host and connect back to a central server or servers that act as a command and control (C&C) center for an entire network of compromised devices, or botnet.
+    # A malicious bot is self-propagating malware designed to infect a host and connect back to a central server
+    # or servers that act as a command and control (C&C) center for an entire network of compromised devices,
+    # or botnet.
     bot = "bot"
 
-    # A browser hijacker is defined as a form of unwanted software that modifies a web browser's settings without the user's permission. The result is the placement of unwanted advertising into the browser, and possibly the replacement of an existing home page or search page with the hijacker page.
+    # A browser hijacker is defined as a form of unwanted software that modifies a web browser's settings without
+    # the user's permission. The result is the placement of unwanted advertising into the browser,
+    # and possibly the replacement of an existing home page or search page with the hijacker page.
     browser_hijacker = "browser_hijacker"
 
-    # Trojan bruteforcer are trying to brute force website in order to achieve something else (EX: Finding  WordPress websites with default credentials).
+    # Trojan bruteforcer are trying to brute force website in order to achieve something else
+    # (EX: Finding  WordPress websites with default credentials).
     bruteforcer = "bruteforcer"
 
-    # A type of trojan that can use your PC to 'click' on websites or applications. They are usually used to make money for a malicious hacker by clicking on online advertisements and making it look like the website gets more traffic than it does. They can also be used to skew online polls, install programs on your PC, or make unwanted software appear more popular than it is.
+    # A type of trojan that can use your PC to 'click' on websites or applications.
+    # They are usually used to make money for a malicious hacker by clicking on online advertisements
+    # and making it look like the website gets more traffic than it does.
+    # They can also be used to skew online polls, install programs on your PC, or make unwanted software
+    # appear more popular than it is.
     clickfraud = "clickfraud"
 
     # Cryptocurrency mining malware.
     cryptominer = "cryptominer"
 
-    # These programs conduct DoS (Denial of Service) attacks against a targeted web address. By sending multiple requests from your computer and several other infected computers, the attack can overwhelm the target address leading to a denial of service.
+    # These programs conduct DoS (Denial of Service) attacks against a targeted web address.
+    # By sending multiple requests from your computer and several other infected computers,
+    # the attack can overwhelm the target address leading to a denial of service.
     ddos = "ddos"
 
     # Trojan Downloaders can download and install new versions of malicious programs in the target system.
@@ -92,49 +109,66 @@ class CategoryEnum(str, Enum):
     # These programs are used by hackers in order to install malware or to prevent the detection of malicious programs.
     dropper = "dropper"
 
-    # Exploit kits are programs that contain data or code that takes advantage of a vulnerability within an application that is running in the target system.
+    # Exploit kits are programs that contain data or code that takes advantage of a vulnerability
+    # within an application that is running in the target system.
     exploitkit = "exploitkit"
 
-    # Trojan FakeAV programs simulate the activity of antivirus software. They are designed to extort money in return for the detection and removal of threat, even though the threats that they report are actually non-existent.
+    # Trojan FakeAV programs simulate the activity of antivirus software.
+    # They are designed to extort money in return for the detection and removal of threat, even though the
+    # threats that they report are actually non-existent.
     fakeav = "fakeav"
 
     # A type of tool that can be used to allow and maintain unauthorized access to your PC.
     hacktool = "hacktool"
 
-    # A program that collects your personal information, such as your browsing history, and uses it without adequate consent.
+    # A program that collects your personal information, such as your browsing history,
+    # and uses it without adequate consent.
     infostealer = "infostealer"
 
-    # A keylogger monitors and logs every keystroke it can identify. Once installed, the virus either keeps track of all the keys and stores the information locally, after which the hacker needs physical access to the computer to retrieve the information, or the logs are sent over the internet back to the hacker.
+    # A keylogger monitors and logs every keystroke it can identify.
+    # Once installed, the virus either keeps track of all the keys and stores the information locally,
+    # after which the hacker needs physical access to the computer to retrieve the information,
+    # or the logs are sent over the internet back to the hacker.
     keylogger = "keylogger"
 
     # A program that loads another application / memory space.
     loader = "loader"
 
-    # A type of malware that hides its code and purpose to make it more difficult for security software to detect or remove it.
+    # A type of malware that hides its code and purpose to make it more difficult for
+    # security software to detect or remove it.
     obfuscator = "obfuscator"
 
-    # Point-of-sale malware is usually a type of malware that is used by cybercriminals to target point of sale (POS) and payment terminals with the intent to obtain credit card and debit card information.
+    # Point-of-sale malware is usually a type of malware that is used by cybercriminals to target point of sale (POS)
+    # and payment terminals with the intent to obtain credit card and debit card information.
     pos = "pos"
 
-    # This type of trojan allows unauthorized parties to use the infected computer as a proxy server to access the Internet anonymously.
+    # This type of trojan allows unauthorized parties to use the infected computer as a proxy server
+    # to access the Internet anonymously.
     proxy = "proxy"
 
     # A program that can be used by a remote hacker to gain access and control of an infected machine.
     rat = "rat"
 
-    # This type of malware can modify data in the target computer so the operating system will stop running correctly or the data is no longer accessible. The criminal will only restore the computer state or data after a ransom is paid to them (mostly using cryptocurrency).
+    # This type of malware can modify data in the target computer so the operating system
+    # will stop running correctly or the data is no longer accessible.
+    # The criminal will only restore the computer state or data after a ransom is paid to them
+    # (mostly using cryptocurrency).
     ransomware = "ransomware"
 
     # A reverse proxy is a server that receives requests from the internet and forwards them to a small set of servers.
     reverse_proxy = "reverse_proxy"
 
-    # Rootkits are designed to conceal certain objects or activities in the system. Often their main purpose is to prevent malicious programs being detected in order to extend the period in which programs can run on an infected computer.
+    # Rootkits are designed to conceal certain objects or activities in the system.
+    # Often their main purpose is to prevent malicious programs being detected
+    # in order to extend the period in which programs can run on an infected computer.
     rootkit = "rootkit"
 
-    # This type of malware scan the internet / network(s) / system(s) / service(s) to collect information. That information could be used later to perpetuate an cyber attack.
+    # This type of malware scan the internet / network(s) / system(s) / service(s) to collect information.
+    # That information could be used later to perpetuate an cyber attack.
     scanner = "scanner"
 
-    # Scareware is a form of malware which uses social engineering to cause shock, anxiety, or the perception of a threat in order to manipulate users into buying unwanted software.
+    # Scareware is a form of malware which uses social engineering to cause shock, anxiety,
+    # or the perception of a threat in order to manipulate users into buying unwanted software.
     scareware = "scareware"
 
     # Malware that is sending spam.

--- a/maco/utils.py
+++ b/maco/utils.py
@@ -179,10 +179,12 @@ def scan_for_extractors(root_directory: str, scanner: yara.Rules, logger: Logger
                         for pattern in [RELATIVE_FROM_IMPORT_RE, RELATIVE_FROM_RE]:
                             for match in pattern.findall(data):
                                 depth = match.count(".")
+                                abspath='.'.join(split[depth - 1 : split.index(package) + 1][::-1])
+                                abspath+='.' if pattern == RELATIVE_FROM_RE else ''
                                 data = data.replace(
                                     f"from {match}",
-                                    f"from {'.'.join(split[depth - 1 : split.index(package) + 1][::-1])}{'.' if pattern == RELATIVE_FROM_RE else ''}",
-                                    1,
+                                    f"from {abspath}",
+                                    1
                                 )
                         f.write(data)
 

--- a/maco/utils.py
+++ b/maco/utils.py
@@ -222,7 +222,12 @@ def _install_required_packages(create_venv: bool, directories: List[str], python
                         subprocess.run(cmd.split(" ") + [venv_path], capture_output=True, env=env)
 
                 # Install/Update the packages in the environment
-                install_command = PIP_CMD.split(" ") + ["install", "-U"]
+                install_command = PIP_CMD.split(" ") + ["install"]
+                # When running locally, only install packages to required spec.
+                # This prevents issues during maco development and building extractors against local libraries.
+                if create_venv:
+                    # when running in custom virtual environment, always upgrade packages.
+                    install_command.append("-U")
 
                 # Update the pip install command depending on where the dependencies are coming from
                 if "requirements.txt" in req_files:

--- a/maco/utils.py
+++ b/maco/utils.py
@@ -46,6 +46,7 @@ UV_BIN = find_uv_bin()
 PIP_CMD = f"{UV_BIN} pip"
 VENV_CREATE_CMD = f"{UV_BIN} venv"
 
+
 class Base64Decoder(json.JSONDecoder):
     def __init__(self, *args, **kwargs):
         json.JSONDecoder.__init__(self, object_hook=self.object_hook, *args, **kwargs)
@@ -179,13 +180,9 @@ def scan_for_extractors(root_directory: str, scanner: yara.Rules, logger: Logger
                         for pattern in [RELATIVE_FROM_IMPORT_RE, RELATIVE_FROM_RE]:
                             for match in pattern.findall(data):
                                 depth = match.count(".")
-                                abspath='.'.join(split[depth - 1 : split.index(package) + 1][::-1])
-                                abspath+='.' if pattern == RELATIVE_FROM_RE else ''
-                                data = data.replace(
-                                    f"from {match}",
-                                    f"from {abspath}",
-                                    1
-                                )
+                                abspath = ".".join(split[depth - 1 : split.index(package) + 1][::-1])
+                                abspath += "." if pattern == RELATIVE_FROM_RE else ""
+                                data = data.replace(f"from {match}", f"from {abspath}", 1)
                         f.write(data)
 
                 if scanner.match(path):
@@ -314,8 +311,10 @@ def register_extractors(
     parent_directory = os.path.dirname(current_directory)
     if venvs and package_name in sys.modules:
         # this may happen as part of testing if some part of the extractor code was directly imported
-        logger.warning(f"Looks like {package_name} is already loaded. "
-                       "If your maco extractor overlaps an existing package name this could cause problems.")
+        logger.warning(
+            f"Looks like {package_name} is already loaded. "
+            "If your maco extractor overlaps an existing package name this could cause problems."
+        )
 
     try:
         # Modify the PATH so we can recognize this new package on import
@@ -390,6 +389,7 @@ def register_extractors(
                 # We were able to find all the extractor files
                 break
 
+
 def proxy_logging(queue: multiprocessing.Queue, callback: Callable[[ModuleType, str], None], *args, **kwargs):
     """Ensures logging is set up correctly for a child process and then executes the callback."""
     logger = logging.getLogger()
@@ -397,6 +397,7 @@ def proxy_logging(queue: multiprocessing.Queue, callback: Callable[[ModuleType, 
     qh.setLevel(logging.DEBUG)
     logger.addHandler(qh)
     callback(*args, **kwargs, logger=logger)
+
 
 def import_extractors(
     extractor_module_callback: Callable[[ModuleType, str], bool],
@@ -423,6 +424,7 @@ def import_extractors(
 # holds cached extractors when not running in venv mode
 _loaded_extractors: Dict[str, Extractor] = {}
 
+
 def run_extractor(
     sample_path,
     module_name,
@@ -445,7 +447,7 @@ def run_extractor(
             extractor = _loaded_extractors[key]
         if extractor.yara_compiled:
             matches = extractor.yara_compiled.match(sample_path)
-        loaded = extractor.run(open(sample_path, 'rb'), matches=matches)
+        loaded = extractor.run(open(sample_path, "rb"), matches=matches)
     else:
         # execute extractor in child process with separate virtual environment
         # Write temporary script in the same directory as extractor to resolve relative imports
@@ -484,7 +486,7 @@ def run_extractor(
                 try:
                     # Load results and return them
                     output.seek(0)
-                    loaded =  json.load(output, cls=json_decoder)
+                    loaded = json.load(output, cls=json_decoder)
                 except Exception as e:
                     # If there was an error raised during runtime, then propagate
                     delim = f'File "{module_path}"'

--- a/maco/yara.py
+++ b/maco/yara.py
@@ -3,7 +3,6 @@ from collections import namedtuple
 from itertools import cycle
 from typing import Dict
 
-import yara
 import yara_x
 
 RULE_ID_RE = re.compile("(\w+)? ?rule (\w+)")

--- a/pipelines/test.yaml
+++ b/pipelines/test.yaml
@@ -7,6 +7,27 @@ pool:
   vmImage: "ubuntu-22.04"
 
 jobs:
+  - job: style_test
+    strategy:
+      matrix:
+        Python3_12:
+          python.version: "3.12"
+    timeoutInMinutes: 10
+
+    steps:
+      - task: UsePythonVersion@0
+        displayName: Set python version
+        inputs:
+          versionSpec: "$(python.version)"
+
+      - script: |
+          python -m pip install -U tox
+        displayName: Install tox
+
+      - script: |
+          python -m tox -e style
+        displayName: "Run style tests"
+
   - job: run_test
     strategy:
       matrix:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,3 +41,12 @@ dependencies = { file = ["requirements.txt"] }
 [tool.setuptools.packages.find]
 where = ["."]
 exclude = ["test", "tests", "extractors", "model_setup"]
+
+[tool.ruff]
+line-length = 119
+
+[tool.ruff.lint]
+# Add the `line-too-long` rule to the enforced rule set. By default, Ruff omits rules that
+# overlap with the use of a formatter, like Black, but we can override this behavior by
+# explicitly adding the rule.
+extend-select = ["E501"]

--- a/tests/extractors/bob/bob.py
+++ b/tests/extractors/bob/bob.py
@@ -1,4 +1,3 @@
-
 from maco import extractor
 
 

--- a/tests/extractors/bob/bob.py
+++ b/tests/extractors/bob/bob.py
@@ -1,7 +1,5 @@
-from io import BytesIO
-from typing import List, Optional
 
-from maco import extractor, model, yara
+from maco import extractor
 
 
 class Bob(extractor.Extractor):

--- a/tests/test_base_test.py
+++ b/tests/test_base_test.py
@@ -22,6 +22,7 @@ class TestLimitOther(base_test.BaseTest):
 
 class TestComplex(base_test.BaseTest):
     """Test that complex extractor can be used in base environment."""
+
     name = "Complex"
     path = os.path.join(__file__, "../../demo_extractors")
     create_venv = False
@@ -47,8 +48,10 @@ class TestComplex(base_test.BaseTest):
         result = instance.run(data, [])
         self.assertEqual(result.family, "complex")
 
+
 class TestComplexVenv(base_test.BaseTest):
     """Test that complex extractor can be used in full venv isolation."""
+
     name = "Complex"
     path = os.path.join(__file__, "../../demo_extractors")
     create_venv = True

--- a/tests/test_demo_extractors.py
+++ b/tests/test_demo_extractors.py
@@ -7,9 +7,7 @@ from maco.collector import Collector
 
 class TestDemoExtractors(unittest.TestCase):
     def test_complex(self):
-        path_file = os.path.normpath(
-            os.path.join(__file__, "../data/trigger_complex.txt")
-        )
+        path_file = os.path.normpath(os.path.join(__file__, "../data/trigger_complex.txt"))
         collector = Collector(os.path.join(__file__, "../../demo_extractors"))
         self.assertEqual(
             set(collector.extractors.keys()),

--- a/tests/test_detection.py
+++ b/tests/test_detection.py
@@ -129,6 +129,8 @@ def test_module_confusion():
 
     import git
 
+    assert git.__name__
+
     # Directories that have the same name as the Python module, shouldn't cause confusion on loading the right module
     collector = Collector(os.path.join(__file__, "../extractors/bob"))
     assert collector.extractors["Bob"]

--- a/tests/test_detection.py
+++ b/tests/test_detection.py
@@ -129,6 +129,7 @@ def test_module_confusion():
 
     import git
 
+    # ensure that the git import is kept
     assert git.__name__
 
     # Directories that have the same name as the Python module, shouldn't cause confusion on loading the right module

--- a/tox.ini
+++ b/tox.ini
@@ -15,5 +15,5 @@ deps =
     ruff
 # run the tests
 commands =
-  ruff check
   ruff format --check
+  ruff check

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py38,py39,py310,py311,py312
+envlist = py38,py39,py310,py311,py312,style
 [testenv]
 # install testing framework
 deps =
@@ -8,3 +8,10 @@ deps =
     -r tests/requirements.txt
 # run the tests
 commands = python -m pytest tests/ -p no:cacheprovider --durations=10 -ra -q -k "not git and not extractors" -vv -W ignore::DeprecationWarning
+
+[testenv:style]
+# install testing framework
+deps =
+    ruff
+# run the tests
+commands = ruff check

--- a/tox.ini
+++ b/tox.ini
@@ -14,4 +14,6 @@ commands = python -m pytest tests/ -p no:cacheprovider --durations=10 -ra -q -k 
 deps =
     ruff
 # run the tests
-commands = ruff check
+commands =
+  ruff check
+  ruff format --check


### PR DESCRIPTION
Using Ruff, https://docs.astral.sh/ruff/.

This adds line length checking of 120 characters, as well as default ruff linting and style checking.

I've also fixed a small issue when developing maco locally - the change means that packages for extractors are not upgraded after the first install unless `create_venv=true`.
Additionally, I've fixed an importing issue on the cli by adding to sys.path when the Collection() is initialised.

Addresses #72 