### PR TITLE
fix: resolve runtime collector failure

### DIFF
--- a/maco/collector.py
+++ b/maco/collector.py
@@ -5,11 +5,11 @@ import logging
 import logging.handlers
 import os
 import sys
-from multiprocessing import Manager, Process, Queue
 from tempfile import NamedTemporaryFile
 from types import ModuleType
-from typing import Any, BinaryIO, Dict, List, Union
+from typing import Any, BinaryIO, Dict, List, TypedDict, Union
 
+from multiprocess import Manager, Process, Queue
 from pydantic import BaseModel
 
 from maco import extractor, model, utils, yara
@@ -40,6 +40,26 @@ def _verify_response(resp: Union[BaseModel, dict]) -> Dict:
     return resp.model_dump(exclude_defaults=True)
 
 
+class ExtractorMetadata(TypedDict):
+    """Extractor-supplied metadata."""
+
+    author: str
+    family: str
+    last_modified: str
+    sharing: str
+    description: str
+
+
+class ExtractorRegistration(TypedDict):
+    """Registration collected by the collector for a single extractor."""
+
+    venv: str
+    module_path: str
+    module_name: str
+    extractor_class: str
+    metadata: ExtractorMetadata
+
+
 class Collector:
     def __init__(
         self,
@@ -60,7 +80,7 @@ class Collector:
 
         path_extractors = os.path.realpath(path_extractors)
         self.path: str = path_extractors
-        self.extractors: Dict[str, Dict[str, str]] = {}
+        self.extractors: Dict[str, ExtractorRegistration] = {}
 
         with Manager() as manager:
             extractors = manager.dict()

--- a/maco/utils.py
+++ b/maco/utils.py
@@ -6,13 +6,14 @@ import inspect
 import json
 import logging
 import logging.handlers
-import multiprocessing
 import os
 import re
 import shutil
 import subprocess
 import sys
 import tempfile
+
+from multiprocess import Queue
 
 from maco import yara
 
@@ -390,7 +391,7 @@ def register_extractors(
                 break
 
 
-def proxy_logging(queue: multiprocessing.Queue, callback: Callable[[ModuleType, str], None], *args, **kwargs):
+def proxy_logging(queue: Queue, callback: Callable[[ModuleType, str], None], *args, **kwargs):
     """Ensures logging is set up correctly for a child process and then executes the callback."""
     logger = logging.getLogger()
     qh = logging.handlers.QueueHandler(queue)

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ tomli >= 1.1.0 ; python_version < "3.11"
 uv
 yara-python
 yara-x==0.11.0
+multiprocess>=0.70.17


### PR DESCRIPTION
Happy New Year :)

This fixes an issue where Maco fails to collect extractors, with something like the following:
```
  File "/usr/local/lib/python3.12/site-packages/maco/collector.py", line 120, in __init__
    p.start()
  File "/usr/local/lib/python3.12/multiprocessing/process.py", line 121, in start
    self._popen = self._Popen(self)
                  ^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/multiprocessing/context.py", line 224, in _Popen
    return _default_context.get_context().Process._Popen(process_obj)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/multiprocessing/context.py", line 301, in _Popen
    return Popen(process_obj)
           ^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/multiprocessing/popen_forkserver.py", line 35, in __init__
    super().__init__(process_obj)
  File "/usr/local/lib/python3.12/multiprocessing/popen_fork.py", line 19, in __init__
    self._launch(process_obj)
  File "/usr/local/lib/python3.12/multiprocessing/popen_forkserver.py", line 47, in _launch
    reduction.dump(process_obj, buf)
  File "/usr/local/lib/python3.12/multiprocessing/reduction.py", line 60, in dump
    ForkingPickler(file, protocol).dump(obj)
AttributeError: Can't get local object 'Collector.__init__.<locals>.extractor_module_callback'
```

Maco tries to pickle a function defined in another function which isn't technically supported by the pickle implementation and as such fails in certain circumstances.

This PR switches Maco over to the `multiprocess` library which uses dill instead & which supports packing functions defined in this way.

This also fixes up some typing issues - happy to separate this out if you would prefer.