### PR TITLE
Added cast to bytes for match function

### DIFF
--- a/maco/yara.py
+++ b/maco/yara.py
@@ -3,7 +3,7 @@
 import re
 from collections import namedtuple
 from itertools import cycle
-from typing import Dict, List
+from typing import Dict, List, Union
 
 import yara_x
 
@@ -104,7 +104,7 @@ class Rules:
         for rule in self._rules:
             yield rule
 
-    def match(self, filepath: str = None, data: bytes = None) -> List[Match]:
+    def match(self, filepath: str = None, data: Union[bytes, str] = None) -> List[Match]:
         """Performs a scan to check for YARA rules matches based on the file, either given by path or buffer.
 
         Returns:
@@ -114,7 +114,8 @@ class Rules:
             with open(filepath, "rb") as fp:
                 data = fp.read()
 
-        data = bytes(data)
+        if isinstance(data, str):
+            data = bytes(data)
 
         return [Match(m, data) for m in self.scanner.scan(data).matching_rules]
 

--- a/maco/yara.py
+++ b/maco/yara.py
@@ -51,7 +51,7 @@ class StringMatch:
         Returns:
             (bool): True if match is xor'd
         """
-        return self._is_xorz
+        return self._is_xor
 
 
 class Match:

--- a/maco/yara.py
+++ b/maco/yara.py
@@ -104,7 +104,7 @@ class Rules:
         for rule in self._rules:
             yield rule
 
-    def match(self, filepath: str = None, data: Union[bytes, str] = None) -> List[Match]:
+    def match(self, filepath: str = None, data: Union[bytes, bytearray] = None) -> List[Match]:
         """Performs a scan to check for YARA rules matches based on the file, either given by path or buffer.
 
         Returns:
@@ -114,7 +114,7 @@ class Rules:
             with open(filepath, "rb") as fp:
                 data = fp.read()
 
-        if isinstance(data, str):
+        if isinstance(data, bytearray):
             data = bytes(data)
 
         return [Match(m, data) for m in self.scanner.scan(data).matching_rules]

--- a/maco/yara.py
+++ b/maco/yara.py
@@ -3,7 +3,7 @@
 import re
 from collections import namedtuple
 from itertools import cycle
-from typing import Dict, List, Tuple
+from typing import Dict, List
 
 import yara_x
 

--- a/maco/yara.py
+++ b/maco/yara.py
@@ -66,10 +66,7 @@ class Match:
         # Ensure metadata doesn't get overwritten
         for k, v in rule.metadata:
             self.meta.setdefault(k, []).append(v)
-        self.strings = []
-        for match in [StringMatch(pattern, file_content) for pattern in rule.patterns]:
-            for instance in match.instances:
-                self.strings.append((instance.offset, match.identifier, instance.matched_data))
+        self.strings = [StringMatch(pattern, file_content) for pattern in rule.patterns]
 
 
 class Rules:


### PR DESCRIPTION
Cast to bytes was is sometimes needed as sometimes the data passed in is type bytearray rather than bytes, which is immutable and cannot be used by the scan function