### PR TITLE
Adding 'dead_drop_resolver' to the ConnUsageEnum in model.py

### DIFF
--- a/maco/model/model.py
+++ b/maco/model/model.py
@@ -19,6 +19,7 @@ class ConnUsageEnum(str, Enum):
 
     c2 = "c2"  # issue commands to malware
     upload = "upload"  # get data out of the network
+    dead_drop_resolver = "dead_drop_resolver"  # resolve dead drop locations
     download = "download"  # fetch dynamic config, second stage, etc
     propagate = "propagate"  # spread through the network
     tunnel = "tunnel"  # communicate through the network


### PR DESCRIPTION
While extracting command and control servers (C2) from malware configurations, we often get dead drop resolver URLs from popular web services like: Pastebin, Paste.ee, ControlC, GitHub, GitLab, X, Steam, Telegram and YouTube. Technically, these aren't C2 servers but legitimate websites that get used maliciously for storing the real C2 server. 

This modification adds the new category type `dead_drop_resolver` into the `ConnUsageEnum` object. That way, we could have a better representation of the URL in the malware configuration.

Reference: https://attack.mitre.org/techniques/T1102/001/