### PR TITLE
feat: add warning and pydantic model return

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
-    rev: v0.9.9
+    rev: v0.15.9
     hooks:
       # Run the linter.
       - id: ruff

--- a/README.md
+++ b/README.md
@@ -169,6 +169,9 @@ Install this package with `pip install maco`.
 
 All required Python packages are in the `requirements.txt`.
 
+For tests to pass `libmono` must be installed
+The recommended way to do that on linux is to run the command `sudo apt install mono-devel mono-complete -y`
+
 # CLI Usage
 
 ```bash

--- a/maco/collector.py
+++ b/maco/collector.py
@@ -20,7 +20,7 @@ from maco.exceptions import AnalysisAbortedException, ExtractorLoadError
 logger = logging.getLogger("maco.lib.helpers")
 
 
-def _verify_response(resp: BaseModel | dict) -> dict:
+def _verify_response(resp: BaseModel | dict) -> model.ExtractorModel | None:
     """Enforce types and verify properties, and remove defaults.
 
     Args:
@@ -40,9 +40,7 @@ def _verify_response(resp: BaseModel | dict) -> dict:
     resp = model.ExtractorModel.model_validate(resp)
     # coerce sets to correct types
     # otherwise we end up with sets where we expect lists
-    resp = model.ExtractorModel(**resp.model_dump())
-    # dump model to dict
-    return resp.model_dump(exclude_defaults=True)
+    return model.ExtractorModel(**resp.model_dump())
 
 
 class ExtractorMetadata(TypedDict):
@@ -168,14 +166,14 @@ class Collector:
             # compile yara rules gathered from extractors
             self.rules = yara.compile(sources=dict(namespaced_rules))
 
-    def match(self, stream: BinaryIO) -> dict[str, list[yara.Match]]:
+    def match(self, stream: BinaryIO) -> dict[str, list[yara.Match]] | None:
         """Return extractors that should run based on yara rules."""
         # execute yara rules on file to find extractors we should run
         # yara can't run on a stream so we give it a bytestring
         matches = self.rules.match(data=stream.read())
         stream.seek(0)
         if not matches:
-            return
+            return None
         # get all rules that hit for each extractor
         runs = {}
         for match in matches:
@@ -187,7 +185,7 @@ class Collector:
         self,
         stream: BinaryIO,
         extractor_name: str,
-    ) -> dict[str, Any]:
+    ) -> dict[str, Any] | None:
         """Run extractor with stream and verify output matches the model.
 
         Args:
@@ -196,6 +194,58 @@ class Collector:
 
         Returns:
             (Dict[str, Any]): Results from extractor
+        """
+        extractor = self.extractors[extractor_name]
+        temp_sample_name = None
+        try:
+            # Run extractor on a copy of the sample
+            with NamedTemporaryFile(delete=False) as sample_path:
+                temp_sample_name = sample_path.name
+                sample_path.write(stream.read())
+                sample_path.flush()
+
+            # enforce types and verify properties, and remove defaults
+            return_val = _verify_response(
+                utils.run_extractor(
+                    temp_sample_name,
+                    module_name=extractor["module_name"],
+                    extractor_class=extractor["extractor_class"],
+                    module_path=extractor["module_path"],
+                    venv=extractor["venv"],
+                )
+            )
+            if return_val is None:
+                return
+            return return_val.model_dump(exclude_defaults=True)
+        except AnalysisAbortedException:
+            # Extractor voluntarily aborted analysis of sample
+            return
+        except Exception:
+            # caller can deal with the exception
+            raise
+        finally:
+            # make sure to reset where we are in the file
+            # otherwise follow on extractors are going to read 0 bytes
+            stream.seek(0)
+            if temp_sample_name:
+                try:
+                    os.unlink(temp_sample_name)
+                except FileNotFoundError:
+                    pass
+
+    def extract_model(
+        self,
+        stream: BinaryIO,
+        extractor_name: str,
+    ) -> model.ExtractorModel | None:
+        """Run extractor with stream and verify output matches the model.
+
+        Args:
+            stream (BinaryIO): Binary stream to analyze
+            extractor_name (str): Name of extractor to analyze stream
+
+        Returns:
+            (ExtractorModel|None): Results from extractor or None if the extractor exited early.
         """
         extractor = self.extractors[extractor_name]
         temp_sample_name = None
@@ -218,7 +268,7 @@ class Collector:
             )
         except AnalysisAbortedException:
             # Extractor voluntarily aborted analysis of sample
-            return
+            return None
         except Exception:
             # caller can deal with the exception
             raise

--- a/maco/collector.py
+++ b/maco/collector.py
@@ -195,43 +195,10 @@ class Collector:
         Returns:
             (Dict[str, Any]): Results from extractor
         """
-        extractor = self.extractors[extractor_name]
-        temp_sample_name = None
-        try:
-            # Run extractor on a copy of the sample
-            with NamedTemporaryFile(delete=False) as sample_path:
-                temp_sample_name = sample_path.name
-                sample_path.write(stream.read())
-                sample_path.flush()
-
-            # enforce types and verify properties, and remove defaults
-            return_val = _verify_response(
-                utils.run_extractor(
-                    temp_sample_name,
-                    module_name=extractor["module_name"],
-                    extractor_class=extractor["extractor_class"],
-                    module_path=extractor["module_path"],
-                    venv=extractor["venv"],
-                )
-            )
-            if return_val is None:
-                return
-            return return_val.model_dump(exclude_defaults=True)
-        except AnalysisAbortedException:
-            # Extractor voluntarily aborted analysis of sample
+        return_val = self.extract_model(stream=stream, extractor_name=extractor_name)
+        if return_val is None:
             return
-        except Exception:
-            # caller can deal with the exception
-            raise
-        finally:
-            # make sure to reset where we are in the file
-            # otherwise follow on extractors are going to read 0 bytes
-            stream.seek(0)
-            if temp_sample_name:
-                try:
-                    os.unlink(temp_sample_name)
-                except FileNotFoundError:
-                    pass
+        return return_val.model_dump(exclude_defaults=True)
 
     def extract_model(
         self,

--- a/maco/model/model.py
+++ b/maco/model/model.py
@@ -786,6 +786,6 @@ class ExtractorModel(ForbidModel):
         """
 
         message: str
-        stack_trace: str
+        stack_trace: str = ""
 
     warnings: list[Warning] = []

--- a/maco/model/model.py
+++ b/maco/model/model.py
@@ -788,4 +788,4 @@ class ExtractorModel(ForbidModel):
         message: str
         stack_trace: str
 
-    warnings: list[Warning]
+    warnings: list[Warning] = []

--- a/maco/model/model.py
+++ b/maco/model/model.py
@@ -777,3 +777,15 @@ class ExtractorModel(ForbidModel):
         """Scheduled task usage by malware."""
 
     scheduled_tasks: list[ScheduledTask] = []
+
+    class Warning(ForbidModel):
+        """List of warnings for extraction actions that went wrong but were recovered.
+
+        Useful when an extractor can get some information out of a binary but;
+        can't fully extract other information as expected.
+        """
+
+        message: str
+        stack_trace: str
+
+    warnings: list[Warning]

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -329,6 +329,8 @@ class TestModelObject(unittest.TestCase):
     def verify(self, in1, in2: dict) -> dict:
         """Verify the returned data matches the schema."""
         resp = collector._verify_response(in1)
+        if resp:
+            resp = resp.model_dump(exclude_defaults=True)
         self.assertEqual(resp, in2)
 
 
@@ -442,4 +444,6 @@ class TestModelDict(unittest.TestCase):
         """Verify the returned data matches the schema."""
         tmp = model.ExtractorModel.model_validate(config)
         resp = collector._verify_response(tmp)
+        if resp:
+            resp = resp.model_dump(exclude_defaults=True)
         self.assertEqual(resp, config)

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -326,7 +326,294 @@ class TestModelObject(unittest.TestCase):
             },
         )
 
-    def verify(self, in1, in2: dict) -> dict:
+    def test_model_object_3(self):
+        """Test the model object with more data."""
+        em = model.ExtractorModel
+        tmp = model.ExtractorModel(
+            family="scuba",
+            version="lotso_stuff",
+            category=[],
+            attack=[],
+            capability_enabled=[],
+            capability_disabled=[],
+            campaign_id=["32"],
+            identifier=["uxuduxuduxuudux"],
+            decoded_strings=["there", "are", "some", "strings"],
+            password=["hunter2"],
+            mutex=["YEAH"],
+            pipe=["xiod"],
+            sleep_delay=45000,
+            sleep_delay_jitter=2500,
+            inject_exe=["Teams.exe"],
+            other={"misc_data": {"nested": 5}},
+            binaries=[
+                em.Binary(
+                    datatype=None,
+                    data=b"\x10\x20\x30\x40",
+                    other={
+                        "datatype": ["payload"],
+                        "extension": [".invalid"],
+                        "label": ["xor 0x04 at 0x2130-0x2134"],
+                        "some_junk": [1, 2, 3, 4, 5, 6],
+                    },
+                    encryption=em.Binary.Encryption(
+                        algorithm="alxor",
+                        public_key=None,
+                        key=None,
+                        provider=None,
+                        mode=None,
+                        iv=None,
+                        seed=None,
+                        nonce=None,
+                        password=None,
+                        salt=None,
+                        constants=[],
+                        usage="binary",
+                    ),
+                ),
+                em.Binary(
+                    datatype=None,
+                    data=b"\x50\x60\x70\x80",
+                    other={"datatype": ["payload"]},
+                    encryption=[
+                        em.Binary.Encryption(
+                            algorithm="alxor",
+                            public_key=None,
+                            key=None,
+                            provider=None,
+                            mode=None,
+                            iv=None,
+                            seed=None,
+                            nonce=None,
+                            password=None,
+                            salt=None,
+                            constants=[],
+                            usage="binary",
+                        ),
+                        em.Binary.Encryption(
+                            algorithm="RC4",
+                            public_key=None,
+                            key=None,
+                            provider=None,
+                            mode=None,
+                            iv=None,
+                            seed=None,
+                            nonce=None,
+                            password=None,
+                            salt=None,
+                            constants=[],
+                            usage="binary",
+                        ),
+                    ],
+                ),
+            ],
+            ftp=[
+                em.FTP(
+                    username=None,
+                    password=None,
+                    hostname="somewhere",
+                    port=None,
+                    path=None,
+                    usage="c2",
+                )
+            ],
+            smtp=[
+                em.SMTP(
+                    username=None,
+                    password=None,
+                    hostname="here.com",
+                    port=None,
+                    mail_to=[],
+                    mail_from=None,
+                    subject=None,
+                    usage="upload",
+                )
+            ],
+            http=[
+                em.Http(
+                    uri=None,
+                    protocol="https",
+                    username=None,
+                    password=None,
+                    hostname="blarg.com",
+                    port=None,
+                    path="/malz",
+                    query=None,
+                    fragment=None,
+                    user_agent=None,
+                    method=None,
+                    headers=None,
+                    max_size=None,
+                    usage="c2",
+                )
+            ],
+            ssh=[
+                em.SSH(
+                    username=None,
+                    password=None,
+                    hostname="bad.malware",
+                    port=None,
+                    usage="download",
+                )
+            ],
+            proxy=[
+                em.Proxy(
+                    protocol=None,
+                    username=None,
+                    password=None,
+                    hostname="192.168.0.80",
+                    port=None,
+                    usage="tunnel",
+                )
+            ],
+            icmp=[
+                em.ICMP(
+                    type=None,
+                    code=None,
+                    header="DEADBEEF",
+                    hostname="192.168.0.80",
+                    usage="c2",
+                )
+            ],
+            dns=[em.DNS(ip="123.21.21.21", port=None, usage="other")],
+            tcp=[
+                em.Connection(
+                    client_ip=None,
+                    client_port=None,
+                    server_ip="73.21.32.43",
+                    server_domain=None,
+                    server_port=None,
+                    usage="c2",
+                )
+            ],
+            udp=[
+                em.Connection(
+                    client_ip=None,
+                    client_port=None,
+                    server_ip="73.21.32.43",
+                    server_domain=None,
+                    server_port=None,
+                    usage="c2",
+                )
+            ],
+            encryption=[
+                em.Encryption(
+                    algorithm="alxor",
+                    public_key=None,
+                    key=None,
+                    provider=None,
+                    mode=None,
+                    iv=None,
+                    seed=None,
+                    nonce=None,
+                    password=None,
+                    salt=None,
+                    constants=[],
+                    usage="binary",
+                )
+            ],
+            service=[
+                em.Service(
+                    dll=None,
+                    name="DeviceMonitorSvc",
+                    display_name="DeviceMonitorSvc",
+                    description="Device Monitor Service",
+                )
+            ],
+            cryptocurrency=[
+                em.Cryptocurrency(
+                    coin="APE",
+                    address="689fdh658790d6dr987yth84iyth7er8gtrfohyt9",
+                    ransom_amount=None,
+                    usage="miner",
+                )
+            ],
+            paths=[
+                em.Path(path="C:/Windows/system32", usage="install"),
+                em.Path(path="C:/user/USERNAME/xxxxx/xxxxx/", usage="logs"),
+                em.Path(path="\\here\\is\\some\\place", usage="install"),
+            ],
+            registry=[
+                em.Registry(key="HKLM_LOCAL_USER/some/location/to/key", usage="store_data"),
+                em.Registry(key="HKLM_LOCAL_USER/system/location", usage="read"),
+            ],
+            warnings=[
+                em.Warning(message="random warning message"),
+                em.Warning(message="random warning message with trace", stack_trace="Stack trace value!"),
+            ],
+        )
+        self.verify(
+            tmp,
+            {
+                "family": "scuba",
+                "version": "lotso_stuff",
+                "campaign_id": ["32"],
+                "identifier": ["uxuduxuduxuudux"],
+                "decoded_strings": ["there", "are", "some", "strings"],
+                "password": ["hunter2"],
+                "mutex": ["YEAH"],
+                "pipe": ["xiod"],
+                "sleep_delay": 45000,
+                "sleep_delay_jitter": 2500,
+                "inject_exe": ["Teams.exe"],
+                "other": {"misc_data": {"nested": 5}},
+                "binaries": [
+                    {
+                        "data": b"\x10 0@",
+                        "other": {
+                            "datatype": ["payload"],
+                            "extension": [".invalid"],
+                            "label": ["xor 0x04 at 0x2130-0x2134"],
+                            "some_junk": [1, 2, 3, 4, 5, 6],
+                        },
+                        "encryption": {"algorithm": "alxor", "usage": "binary"},
+                    },
+                    {
+                        "data": b"P`p\x80",
+                        "other": {"datatype": ["payload"]},
+                        "encryption": [
+                            {"algorithm": "alxor", "usage": "binary"},
+                            {"algorithm": "RC4", "usage": "binary"},
+                        ],
+                    },
+                ],
+                "ftp": [{"hostname": "somewhere", "usage": "c2"}],
+                "smtp": [{"hostname": "here.com", "usage": "upload"}],
+                "http": [{"protocol": "https", "hostname": "blarg.com", "path": "/malz", "usage": "c2"}],
+                "ssh": [{"hostname": "bad.malware", "usage": "download"}],
+                "proxy": [{"hostname": "192.168.0.80", "usage": "tunnel"}],
+                "icmp": [{"header": "DEADBEEF", "hostname": "192.168.0.80", "usage": "c2"}],
+                "dns": [{"ip": "123.21.21.21", "usage": "other"}],
+                "tcp": [{"server_ip": "73.21.32.43", "usage": "c2"}],
+                "udp": [{"server_ip": "73.21.32.43", "usage": "c2"}],
+                "encryption": [{"algorithm": "alxor", "usage": "binary"}],
+                "service": [
+                    {
+                        "name": "DeviceMonitorSvc",
+                        "display_name": "DeviceMonitorSvc",
+                        "description": "Device Monitor Service",
+                    }
+                ],
+                "cryptocurrency": [
+                    {"coin": "APE", "address": "689fdh658790d6dr987yth84iyth7er8gtrfohyt9", "usage": "miner"}
+                ],
+                "paths": [
+                    {"path": "C:/Windows/system32", "usage": "install"},
+                    {"path": "C:/user/USERNAME/xxxxx/xxxxx/", "usage": "logs"},
+                    {"path": "\\here\\is\\some\\place", "usage": "install"},
+                ],
+                "registry": [
+                    {"key": "HKLM_LOCAL_USER/some/location/to/key", "usage": "store_data"},
+                    {"key": "HKLM_LOCAL_USER/system/location", "usage": "read"},
+                ],
+                "warnings": [
+                    {"message": "random warning message"},
+                    {"message": "random warning message with trace", "stack_trace": "Stack trace value!"},
+                ],
+            },
+        )
+
+    def verify(self, in1, in2: dict):
         """Verify the returned data matches the schema."""
         resp = collector._verify_response(in1)
         if resp:
@@ -440,7 +727,101 @@ class TestModelDict(unittest.TestCase):
             }
         )
 
-    def verify(self, config: dict) -> dict:
+    def test_model_with_warnings(self):
+        """Test the model object with more data."""
+        # dict example large
+        self.maxDiff = None
+
+        self.verify(
+            {
+                "family": "scuba",
+                "version": "lotso_stuff",
+                "binaries": [
+                    {
+                        "data": rb"\x10\x20\x30\x40",
+                        "encryption": {"algorithm": "alxor", "usage": "binary"},
+                        "other": {
+                            "datatype": ["payload"],
+                            "extension": [".invalid"],
+                            "label": ["xor 0x04 at 0x2130-0x2134"],
+                            "some_junk": [1, 2, 3, 4, 5, 6],
+                        },
+                    },
+                    {
+                        "data": rb"\x50\x60\x70\x80",
+                        "encryption": [
+                            {"algorithm": "alxor", "usage": "binary"},
+                            {"algorithm": "RC4", "usage": "binary"},
+                        ],
+                        "other": {
+                            "datatype": ["payload"],
+                        },
+                    },
+                ],
+                "ftp": [{"hostname": "somewhere", "usage": "c2"}],
+                "smtp": [{"hostname": "here.com", "usage": "upload"}],
+                "http": [
+                    {
+                        "protocol": "https",
+                        "hostname": "blarg.com",
+                        "path": "/malz",
+                        "usage": "c2",
+                    }
+                ],
+                "ssh": [{"hostname": "bad.malware", "usage": "download"}],
+                "proxy": [{"hostname": "192.168.0.80", "usage": "tunnel"}],
+                "dns": [{"ip": "123.21.21.21", "usage": "other"}],
+                "tcp": [{"server_ip": "73.21.32.43", "usage": "c2"}],
+                "udp": [{"server_ip": "73.21.32.43", "usage": "c2"}],
+                "encryption": [{"algorithm": "alxor", "usage": "binary"}],
+                "service": [
+                    {
+                        "name": "DeviceMonitorSvc",
+                        "display_name": "DeviceMonitorSvc",
+                        "description": "Device Monitor Service",
+                    }
+                ],
+                "cryptocurrency": [
+                    {
+                        "coin": "APE",
+                        "address": "689fdh658790d6dr987yth84iyth7er8gtrfohyt9",
+                        "usage": "miner",
+                    }
+                ],
+                "paths": [
+                    {"path": "C:/Windows/system32", "usage": "install"},
+                    {"path": "C:/user/USERNAME/xxxxx/xxxxx/", "usage": "logs"},
+                    {"path": "\\here\\is\\some\\place", "usage": "install"},
+                ],
+                "registry": [
+                    {
+                        "key": "HKLM_LOCAL_USER/some/location/to/key",
+                        "usage": "store_data",
+                    },
+                    {"key": "HKLM_LOCAL_USER/system/location", "usage": "read"},
+                ],
+                "campaign_id": ["32"],
+                "identifier": ["uxuduxuduxuudux"],
+                "decoded_strings": ["there", "are", "some", "strings"],
+                "password": ["hunter2"],
+                "mutex": ["YEAH"],
+                "pipe": ["xiod"],
+                "sleep_delay": 45000,
+                "inject_exe": ["Teams.exe"],
+                "other": {"misc_data": {"nested": 5}},
+                "warnings": [
+                    {
+                        "message": "warning has occurred",
+                        "stack_trace": "silly stack trace here\nhopefully it helps you find the issue\n",
+                    },
+                    {
+                        "message": "warning has occurred no trace",
+                    },
+                ],
+            }
+        )
+
+    def verify(self, config: dict):
         """Verify the returned data matches the schema."""
         tmp = model.ExtractorModel.model_validate(config)
         resp = collector._verify_response(tmp)


### PR DESCRIPTION
feat: add warning and pydantic model return

- Adds warnings to the Maco return model to allow Azul/Assemblyline to process warning originating from partially working extractors, while still getting as much valid information from the results as possible.
- Adds new extraction method `extract_model` to allow results to be extractor as ExtractorModel rather than a dictionary.
