### PR TITLE
Ignore __pycache__ dirs when looking for extractors

### DIFF
--- a/maco/utils.py
+++ b/maco/utils.py
@@ -200,6 +200,9 @@ def scan_for_extractors(root_directory: str, scanner: yara.Rules, logger: Logger
             elif "deprecated" in node:
                 # Ignore deprecated files
                 continue
+            elif "__pycache__" in node:
+                # Ignore __pycache__ dirs since these cause issues when running in parallel
+                continue
 
             if os.path.isfile(os.path.join(directory, node)):
                 # Scan Python file for potential extractors

--- a/maco/utils.py
+++ b/maco/utils.py
@@ -247,7 +247,7 @@ def _install_required_packages(
 ):
     venvs = []
     env = deepcopy(os.environ)
-    stop_directory = os.path.dirname(sorted(directories)[0])
+    stop_directory = os.path.dirname(min(directories))
     # Track directories that we've already visited
     visited_dirs = []
     for dir in directories:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,7 @@ exclude = ["test", "tests", "extractors", "model_setup", "extractor_setup"]
 
 [tool.ruff]
 line-length = 120
+extend-exclude = ["README.md"]
 
 [tool.ruff.format]
 docstring-code-format = true

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -158,11 +158,13 @@ class TestHelpersAnalyseStream(unittest.TestCase):
             },
         ),
         (
-            'schtasks /create /tn "MyRemoteTask2" /tr "C:\\Scripts\\new\\rackup.cmd" '
-            "/sc ONEVENT /st 02:00 /s REMOTE-PC01 /u DOMAIN\\AdminUser /p AdminPassword123 "
-            '/ru SYSTEM /rp "" /mo 5 /et 04:00 /du 2:00 /sd 01/01/2024 /ed 12/31/2024 '
-            "/hresult 0x1 /v1 /f /rl HIGHEST /delay 00:05:00 /ri 51940 /i 214 /m JAN,MAR,JUL /d 1,15 "
-            '/delay 00:05:00 /ec "System"',
+            (
+                'schtasks /create /tn "MyRemoteTask2" /tr "C:\\Scripts\\new\\rackup.cmd" '
+                "/sc ONEVENT /st 02:00 /s REMOTE-PC01 /u DOMAIN\\AdminUser /p AdminPassword123 "
+                '/ru SYSTEM /rp "" /mo 5 /et 04:00 /du 2:00 /sd 01/01/2024 /ed 12/31/2024 '
+                "/hresult 0x1 /v1 /f /rl HIGHEST /delay 00:05:00 /ri 51940 /i 214 /m JAN,MAR,JUL /d 1,15 "
+                '/delay 00:05:00 /ec "System"'
+            ),
             {
                 "raw_command": 'schtasks /create /tn "MyRemoteTask2" /tr "C:\\Scripts\\new\\rackup.cmd" '
                 '/sc ONEVENT /st 02:00 /s REMOTE-PC01 /u DOMAIN\\AdminUser /p AdminPassword123 /ru SYSTEM /rp "" '


### PR DESCRIPTION
Maco's extractor collector looks inside `__pycache__` directories for extractors to fix, which can lead to a rare race condition error when run or tested in parallel.  Since there shouldn't be any extractors in these directories, it is safe to ignore them.